### PR TITLE
GW capture fix: Quinlan and Shapiro 1987->1989

### DIFF
--- a/src/cmc/cmc_dynamics.c
+++ b/src/cmc/cmc_dynamics.c
@@ -370,12 +370,14 @@ are skipped if they already interacted in 3bb loop!  */
 				S_brem = 0.0;
 
 				if (BH_CAPTURE) {
-					/* cross section for single-single GW capture, from Quinlan and Shapiro 1987 */
+                                        /* cross section for single-single GW capture, from Quinlan and Shapiro 1987 */
+                                        /* Cabrera 220419: updated to use m1 != m2 expression from Quinlan and Shapiro 1989 */
+                                        /* (85 * pi * sqrt(2) / 12)^(2/7) \approx 2.6789966 */
                                         if (star[k].se_k == 14 && star[kp].se_k == 14){
                                                 clight10o7 = pow(2.9979e10 / (units.l/units.t) ,1.428571);
-						rperi = 2.957852 * madhoc * (mass_k + mass_kp) / pow(W,0.57142857) / clight10o7;
-						S_brem = PI * sqr(rperi) * (1.0 + 2.0*madhoc*(mass_k+mass_kp)/(rperi*sqr(W)));
-						S_tmp = MAX(S_tmp, S_brem);
+                                                rperi = 2.6789966 * madhoc * pow(mass_k * mass_kp, 0.28571428) * pow(mass_k + mass_kp, 0.42857143) / pow(W,0.57142857) / clight10o7;
+                                                S_brem = PI * sqr(rperi) * (1.0 + 2.0*madhoc*(mass_k+mass_kp)/(rperi*sqr(W)));
+                                                S_tmp = MAX(S_tmp, S_brem);
 					}
 				}
 

--- a/src/cmc/cmc_sscollision.c
+++ b/src/cmc/cmc_sscollision.c
@@ -606,10 +606,12 @@ void sscollision_do(long k, long kp, double rperimax, double w[4], double W, dou
 		/* Compute the total energy at infinity, then subtract the total 
 		 * amount that is lost to GW during pericenter passage (from 
 		 * Quinlan and Shapiro 1987) */
+		/* Cabrera 220419: updated to use m1 != m2 expression from Quinlan and Shapiro 1989 */
+                /* (85 * pi) / (12 * sqrt(2)) \approx 15.735210 */
 		clight5 = pow(2.9979e10 / (units.l/units.t) ,5);
 
 		Eorbnew = 0.5*madhoc*(mass_k*mass_kp)/(mass_k+mass_kp)*sqr(W);
-		Eorbnew -= 22.252948*pow((mass_k+mass_kp)*madhoc,4.5) / clight5 / pow(rperi,3.5);
+                Eorbnew -= 15.735210 * pow(madhoc, 4.5) * sqr(mass_k * mass_kp) * sqrt(mass_k + mass_kp) / clight5 / pow(rperi,3.5);
         /* 85*pi/12 = 22.252948 */
 
 		afinal = mass_k*mass_kp*madhoc*madhoc / 2. / fabs(Eorbnew); 


### PR DESCRIPTION
Revised GW capture physics in cmc_dynamics.c and cmc_sscollision.c to match Quinlan and Shapiro 1989, eqs. 10-12.  Previous version used the respective expressions from QS 1987, which assumed equal masses.