### PR TITLE
Cmc Updates

### DIFF
--- a/include/cmc/cmc.h
+++ b/include/cmc/cmc.h
@@ -1081,6 +1081,11 @@ typedef struct{
  * @brief Write out information about neutron stars (0=off, 1=on)
  * */
         int WRITE_MOREPULSAR_INFO;
+         #define PARAMDOC_WRITE_MORECOLL_INFO "Write out information about stellar collisions (0=off, 1=on)"
+/**
+ * @brief Write out information about stellar collisions(0=off, 1=on)
+ * */
+ 	int WRITE_MORECOLL_INFO;
 #define PARAMDOC_BHNS_TDE "Treat BH(NS)--MS TDEs in TDE vs direct collision limit (1=TDE, 0=coll)"
 /**
  * @brief Treat BH(NS)--MS TDEs in TDE vs direct collision limit (1=TDE, 0=coll)
@@ -1769,6 +1774,7 @@ void calc_timestep(gsl_rng *rng);
 void energy_conservation1();
 void energy_conservation2();
 void new_orbits_calculate();
+void write_morecoll(long i);
 void toy_rejuvenation();
 void pre_sort_comm();
 void post_sort_comm();

--- a/include/cmc/cmc.h
+++ b/include/cmc/cmc.h
@@ -1081,7 +1081,7 @@ typedef struct{
  * @brief Write out information about neutron stars (0=off, 1=on)
  * */
         int WRITE_MOREPULSAR_INFO;
-         #define PARAMDOC_WRITE_MORECOLL_INFO "Write out information about stellar collisions (0=off, 1=on)"
+#define PARAMDOC_WRITE_MORECOLL_INFO "Write out information about stellar collisions (0=off, 1=on)"
 /**
  * @brief Write out information about stellar collisions(0=off, 1=on)
  * */

--- a/include/cmc/cmc_vars.h
+++ b/include/cmc/cmc_vars.h
@@ -115,7 +115,7 @@ _EXTERN_ int TIMER;
 /* file pointers */
 _EXTERN_ FILE *lagradfile, *dynfile, *lagrad10file, *logfile, *escfile, *snapfile, *ave_mass_file, *densities_file, *no_star_file, *centmass_file, **mlagradfile;
 _EXTERN_ FILE *ke_rad_file, *ke_tan_file, *v2_rad_file, *v2_tan_file;
-_EXTERN_ FILE *binaryfile, *threebbfile, *threebbprobabilityfile, *lightcollisionfile, *threebbdebugfile, *binintfile, *collisionfile, *pulsarfile, *morepulsarfile, *triplefile, *tidalcapturefile, *semergedisruptfile, *removestarfile, *relaxationfile;
+_EXTERN_ FILE *binaryfile, *threebbfile, *threebbprobabilityfile, *lightcollisionfile, *threebbdebugfile, *binintfile, *collisionfile, *pulsarfile, *morepulsarfile, *morecollfile, *triplefile, *tidalcapturefile, *semergedisruptfile, *removestarfile, *relaxationfile;
 _EXTERN_ FILE *corefile;
 _EXTERN_ FILE *fp_lagrad, *fp_log, *fp_denprof;
 _EXTERN_ FILE *timerfile;
@@ -124,27 +124,27 @@ _EXTERN_ FILE *timerfile;
 /**
 * @brief MPI: MPI-IO file pointers corresponding to the C File(pointer)s used in the serial code for files that are needed to be written out using MPI-IO
 */
-_EXTERN_ MPI_File mpi_logfile, mpi_binintfile, mpi_escfile, mpi_collisionfile, mpi_pulsarfile, mpi_morepulsarfile, mpi_triplefile, mpi_tidalcapturefile, mpi_semergedisruptfile, mpi_removestarfile, mpi_relaxationfile;
+_EXTERN_ MPI_File mpi_logfile, mpi_binintfile, mpi_escfile, mpi_collisionfile, mpi_pulsarfile, mpi_morepulsarfile, mpi_morecollfile, mpi_triplefile, mpi_tidalcapturefile, mpi_semergedisruptfile, mpi_removestarfile, mpi_relaxationfile;
 
 /**
 * @brief MPI: String buffers to store intermediate data that is finally flush out to files using MPI-IO
 */
-_EXTERN_ char mpi_logfile_buf[STR_BUF_LEN], mpi_escfile_buf[STR_BUF_LEN], mpi_binintfile_buf[STR_BUF_LEN], mpi_collisionfile_buf[STR_BUF_LEN], mpi_pulsarfile_buf[STR_BUF_LEN], mpi_morepulsarfile_buf[STR_BUF_LEN], mpi_triplefile_buf[STR_BUF_LEN],mpi_tidalcapturefile_buf[STR_BUF_LEN], mpi_semergedisruptfile_buf[STR_BUF_LEN], mpi_removestarfile_buf[STR_BUF_LEN], mpi_relaxationfile_buf[STR_BUF_LEN];
+_EXTERN_ char mpi_logfile_buf[STR_BUF_LEN], mpi_escfile_buf[STR_BUF_LEN], mpi_binintfile_buf[STR_BUF_LEN], mpi_collisionfile_buf[STR_BUF_LEN], mpi_pulsarfile_buf[STR_BUF_LEN], mpi_morepulsarfile_buf[STR_BUF_LEN], mpi_morecollfile_buf[STR_BUF_LEN], mpi_triplefile_buf[STR_BUF_LEN],mpi_tidalcapturefile_buf[STR_BUF_LEN], mpi_semergedisruptfile_buf[STR_BUF_LEN], mpi_removestarfile_buf[STR_BUF_LEN], mpi_relaxationfile_buf[STR_BUF_LEN];
 
 /**
 * @brief MPI: String buffers to store intermediate data that is finally flush out to files using MPI-IO
 */
-_EXTERN_ char mpi_logfile_wrbuf[STR_WRBUF_LEN], mpi_escfile_wrbuf[STR_WRBUF_LEN], mpi_binintfile_wrbuf[STR_WRBUF_LEN], mpi_collisionfile_wrbuf[STR_WRBUF_LEN], mpi_pulsarfile_wrbuf[STR_WRBUF_LEN], mpi_morepulsarfile_wrbuf[STR_WRBUF_LEN], mpi_triplefile_wrbuf[STR_BUF_LEN], mpi_tidalcapturefile_wrbuf[STR_WRBUF_LEN], mpi_semergedisruptfile_wrbuf[STR_WRBUF_LEN], mpi_removestarfile_wrbuf[STR_WRBUF_LEN], mpi_relaxationfile_wrbuf[STR_WRBUF_LEN];
+_EXTERN_ char mpi_logfile_wrbuf[STR_WRBUF_LEN], mpi_escfile_wrbuf[STR_WRBUF_LEN], mpi_binintfile_wrbuf[STR_WRBUF_LEN], mpi_collisionfile_wrbuf[STR_WRBUF_LEN], mpi_pulsarfile_wrbuf[STR_WRBUF_LEN], mpi_morepulsarfile_wrbuf[STR_WRBUF_LEN],  mpi_morecollfile_wrbuf[STR_WRBUF_LEN], mpi_triplefile_wrbuf[STR_BUF_LEN], mpi_tidalcapturefile_wrbuf[STR_WRBUF_LEN], mpi_semergedisruptfile_wrbuf[STR_WRBUF_LEN], mpi_removestarfile_wrbuf[STR_WRBUF_LEN], mpi_relaxationfile_wrbuf[STR_WRBUF_LEN];
 
 /**
 * @brief MPI: Variables to maintail the length of the buffers until the next flush
 */
-_EXTERN_ long long mpi_logfile_len, mpi_escfile_len, mpi_binintfile_len, mpi_collisionfile_len, mpi_pulsarfile_len, mpi_morepulsarfile_len, mpi_triplefile_len, mpi_tidalcapturefile_len, mpi_semergedisruptfile_len, mpi_removestarfile_len, mpi_relaxationfile_len;
+_EXTERN_ long long mpi_logfile_len, mpi_escfile_len, mpi_binintfile_len, mpi_collisionfile_len, mpi_pulsarfile_len, mpi_morepulsarfile_len, mpi_morecollfile_len, mpi_triplefile_len, mpi_tidalcapturefile_len, mpi_semergedisruptfile_len, mpi_removestarfile_len, mpi_relaxationfile_len;
 
 /**
 * @brief MPI: Variables to maintain the total offset of the file
 */
-_EXTERN_ long long mpi_logfile_ofst_total, mpi_escfile_ofst_total, mpi_binaryfile_ofst_total, mpi_binintfile_ofst_total, mpi_collisionfile_ofst_total, mpi_pulsarfile_ofst_total, mpi_morepulsarfile_ofst_total, mpi_triplefile_ofst_total, mpi_tidalcapturefile_ofst_total, mpi_semergedisruptfile_ofst_total, mpi_removestarfile_ofst_total, mpi_relaxationfile_ofst_total;
+_EXTERN_ long long mpi_logfile_ofst_total, mpi_escfile_ofst_total, mpi_binaryfile_ofst_total, mpi_binintfile_ofst_total, mpi_collisionfile_ofst_total, mpi_pulsarfile_ofst_total, mpi_morepulsarfile_ofst_total, mpi_morecollfile_ofst_total, mpi_triplefile_ofst_total, mpi_tidalcapturefile_ofst_total, mpi_semergedisruptfile_ofst_total, mpi_removestarfile_ofst_total, mpi_relaxationfile_ofst_total;
 
 /* Meagan's 3bb files */
 /**
@@ -337,6 +337,7 @@ _EXTERN_ int WRITE_RWALK_INFO;
 _EXTERN_ int WRITE_EXTRA_CORE_INFO;
 _EXTERN_ int WRITE_PULSAR_INFO;
 _EXTERN_ int WRITE_MOREPULSAR_INFO;
+_EXTERN_ int WRITE_MORECOLL_INFO;
 _EXTERN_ int BHNS_TDE;
 _EXTERN_ int CALCULATE10;
 

--- a/src/cmc/cmc_dynamics_helper.c
+++ b/src/cmc/cmc_dynamics_helper.c
@@ -962,6 +962,224 @@ double binint_get_mass(long k, long kp, long id)
 	exit(1);
 }
 
+/**Elena
+* @brief find Radii of merging stars from binary interaction components
+*
+* @param k index of first star
+* @param kp index of second star
+* @param id id of star
+*
+* @return masses of merging stars
+*/
+double binint_get_radii(long k, long kp, long id)
+{
+	/* first look at k */
+	if (star[k].binind == 0) {
+		if (star[k].id == id) {
+			return(star[k].rad);
+		}
+	} else {
+		if (binary[star[k].binind].id1 == id) {
+			return(binary[star[k].binind].rad1);
+		} else if (binary[star[k].binind].id2 == id) {
+			return(binary[star[k].binind].rad2);
+		}
+	}
+	
+	/* then at kp */
+	if (star[kp].binind == 0) {
+		if (star[kp].id == id) {
+			return(star[kp].rad);
+		}
+	} else {
+		if (binary[star[kp].binind].id1 == id) {
+			return(binary[star[kp].binind].rad1);
+		} else if (binary[star[kp].binind].id2 == id) {
+			return(binary[star[kp].binind].rad2);
+		}
+	}
+	
+	eprintf("cannot find matching id %ld!\n", id);
+	exit_cleanly(1, __FUNCTION__);
+	/* this is just for the compiler */
+	exit(1);
+}
+
+/**Elena
+* @brief find core mass of merging stars from binary interaction components
+*
+* @param k index of first star
+* @param kp index of second star
+* @param id id of star
+*
+* @return core  masses of merging stars
+*/
+double binint_get_core_mass(long k, long kp, long id)
+{
+	/* first look at k */
+	if (star[k].binind == 0) {
+		if (star[k].id == id) {
+			return(star[k].se_mc);
+		}
+	} else {
+		if (binary[star[k].binind].id1 == id) {
+			return(binary[star[k].binind].bse_massc[0]);
+			
+		} else if (binary[star[k].binind].id2 == id) {
+			return(binary[star[k].binind].bse_massc[1]);
+			
+		}
+	}
+	
+	/* then at kp */
+	if (star[kp].binind == 0) {
+		if (star[kp].id == id) {
+			return(star[kp].se_mc);
+		}
+	} else {
+		if (binary[star[kp].binind].id1 == id) {
+			return(binary[star[kp].binind].bse_massc[0]);
+		} else if (binary[star[kp].binind].id2 == id) {
+			return(binary[star[kp].binind].bse_massc[1]);
+			
+		}
+	}
+	
+	eprintf("cannot find matching id %ld!\n", id);
+	exit_cleanly(1, __FUNCTION__);
+	/* this is just for the compiler */
+	exit(1);
+}
+
+/**Elena
+* @brief find environment mass of merging stars from binary interaction components
+*
+* @param k index of first star
+* @param kp index of second star
+* @param id id of star
+*
+* @return env masses of merging stars
+*/
+double binint_get_env_mass(long k, long kp, long id)
+{
+	/* first look at k */
+	if (star[k].binind == 0) {
+		if (star[k].id == id) {
+			return(star[k].se_menv);
+		}
+	} else {
+		if (binary[star[k].binind].id1 == id) {
+			return(binary[star[k].binind].bse_menv[0]);
+		} else if (binary[star[k].binind].id2 == id) {
+			return(binary[star[k].binind].bse_menv[1]);
+		}
+	}
+	
+	/* then at kp */
+	if (star[kp].binind == 0) {
+		if (star[kp].id == id) {
+			return(star[kp].se_menv);
+		}
+	} else {
+		if (binary[star[kp].binind].id1 == id) {
+			return(binary[star[kp].binind].bse_menv[0]);
+		} else if (binary[star[kp].binind].id2 == id) {
+			return(binary[star[kp].binind].bse_menv[1]);
+		}
+	}
+	
+	eprintf("cannot find matching id %ld!\n", id);
+	exit_cleanly(1, __FUNCTION__);
+	/* this is just for the compiler */
+	exit(1);
+}
+
+/**Elena
+* @brief find core Radii of merging stars from binary interaction components
+*
+* @param k index of first star
+* @param kp index of second star
+* @param id id of star
+*
+* @return core radii of merging stars
+*/
+double binint_get_core_radii(long k, long kp, long id)
+{
+	/* first look at k */
+	if (star[k].binind == 0) {
+		if (star[k].id == id) {
+			return(star[k].se_rc);
+		}
+	} else {
+		if (binary[star[k].binind].id1 == id) {
+			return(binary[star[k].binind].bse_radc[0]);
+		} else if (binary[star[k].binind].id2 == id) {
+			return(binary[star[k].binind].bse_radc[1]);
+		}
+	}
+	
+	/* then at kp */
+	if (star[kp].binind == 0) {
+		if (star[kp].id == id) {
+			return(star[kp].se_rc);
+		}
+	} else {
+		if (binary[star[kp].binind].id1 == id) {
+			return(binary[star[kp].binind].bse_radc[0]);
+		} else if (binary[star[kp].binind].id2 == id) {
+			return(binary[star[kp].binind].bse_radc[1]);
+		}
+	}
+	
+	eprintf("cannot find matching id %ld!\n", id);
+	exit_cleanly(1, __FUNCTION__);
+	/* this is just for the compiler */
+	exit(1);
+}
+
+/**Elena
+* @brief find core Radii of merging stars from binary interaction components
+*
+* @param k index of first star
+* @param kp index of second star
+* @param id id of star
+*
+* @return core radii of merging stars
+*/
+double binint_get_env_radii(long k, long kp, long id)
+{
+	/* first look at k */
+	if (star[k].binind == 0) {
+		if (star[k].id == id) {
+			return(star[k].se_renv);
+		}
+	} else {
+		if (binary[star[k].binind].id1 == id) {
+			return(binary[star[k].binind].bse_renv[0]);
+		} else if (binary[star[k].binind].id2 == id) {
+			return(binary[star[k].binind].bse_renv[1]);
+		}
+	}
+	
+	/* then at kp */
+	if (star[kp].binind == 0) {
+		if (star[kp].id == id) {
+			return(star[kp].se_renv);
+		}
+	} else {
+		if (binary[star[kp].binind].id1 == id) {
+			return(binary[star[kp].binind].bse_renv[0]);
+		} else if (binary[star[kp].binind].id2 == id) {
+			return(binary[star[kp].binind].bse_renv[1]);
+		}
+	}
+	
+	eprintf("cannot find matching id %ld!\n", id);
+	exit_cleanly(1, __FUNCTION__);
+	/* this is just for the compiler */
+	exit(1);
+}
+
 /**
 * @brief find spins of merging black holes from binary interaction components
 *
@@ -1331,7 +1549,7 @@ void binint_log_collision(const char interaction_type[], long id,
 			  double mass, double r, fb_obj_t obj, long k, long kp, long startype)
 {
 	int j;
-	
+
 	parafprintf(collisionfile, "t=%g %s idm=%ld(mm=%g) id1=%ld(m1=%g)",
 		TotalTime, interaction_type, id, 
 		mass * units.mstar / FB_CONST_MSUN, obj.id[0], 
@@ -1350,10 +1568,77 @@ void binint_log_collision(const char interaction_type[], long id,
 		parafprintf(collisionfile, "type%d=%ld ", j+1, 
 				binint_get_startype(k, kp, obj.id[j]));// Use this, not the Fewbody type, since this is changed by BSE after mergers
 	}
+//Elena: extra output for bs and bb interactions
+	
+	for (j=0; j<obj.ncoll; j++) {
+	        parafprintf(collisionfile, "rad%d[RSUN]=%g ", j+1, binint_get_radii(k, kp, obj.id[j])*units.l/RSUN);
+	}
+
 	parafprintf(collisionfile, "\n");
 }
 
+/**
+* @brief Store additional information in morecollisions file
+*
+* @param interaction_type[] ?
+* @param id ?
+* @param mass ?
+* @param r ?
+* @param obj ?
+* @param k index of star 1
+* @param kp index of star 2
+* @param startype star type
+*/
+void binint_log_morecollision(const char interaction_type[], long remnant_id,
+			  double remnant_mass, double remnant_radius, long remnant_type, double remnant_mc, double remnant_menv, double remnant_rc, 				double remnant_renv, fb_obj_t obj, long k, long kp, double W, double rperi)
+{
 
+	/*remnant radii are already in the right units*/
+	
+	double m0_core = binint_get_core_mass(k, kp, obj.id[0]);
+	double m1_core = binint_get_core_mass(k, kp, obj.id[1]);
+	double m0_env = binint_get_env_mass(k, kp, obj.id[0]);
+	double m1_env = binint_get_env_mass(k, kp, obj.id[1]);
+	
+	double r0_core = binint_get_core_radii(k, kp, obj.id[0]);
+	double r1_core = binint_get_core_radii(k, kp, obj.id[1]);
+	double r0_env = binint_get_env_radii(k, kp, obj.id[0]);
+	double r1_env = binint_get_env_radii(k, kp, obj.id[1]);
+	
+	
+	double rho0_c   = (m0_core) / ((4/3)* PI * pow((r0_core),3));
+	double rho1_c   = (m1_core) / ((4/3)* PI * pow((r1_core),3));
+	double rho0_env = (m0_env)  / ((4/3)* PI * pow((r0_env),3));
+	double rho1_env = (m1_env)  / ((4/3)* PI * pow((r1_env),3));
+	double rhor_c   = (remnant_mc)   / ((4/3)* PI * pow((remnant_rc ),3));
+	double rhor_env = (remnant_menv) / ((4/3)* PI * pow((remnant_renv),3));
+
+	if(isnan(rho0_c)){rho0_c = -100;}
+	if(isnan(rho1_c)){rho1_c = -100;}
+	if(isnan(rhor_c)){rhor_c = -100;}
+	if(isnan(rho0_env)){rho0_env = -100;}
+	if(isnan(rho1_env)){rho1_env = -100;}
+	if(isnan(rhor_env)){rhor_env = -100;}
+	
+	// Elena: For some stars, COSMIC assigns default renv and menv values of of e-10, which makes my densities exactly 3.1831e-19. I will change these vales to output a -100 intead, since it is not physical //
+	
+
+	if(rho0_env >= 1.0e19){rho0_env = -100;}
+	if(rho1_env >= 1.0e19){rho1_env = -100;}
+	if(rhor_env >= 1.0e19){rhor_env = -100;}
+
+	parafprintf(morecollfile, "%g %s %ld %ld %g %g %g %g %g %g %g %g %d %d %ld %g %g %g %g %d %g %g\n",
+				    TotalTime, interaction_type, obj.id[0], obj.id[1], 
+				    binint_get_mass(k, kp, obj.id[0]) * units.mstar / FB_CONST_MSUN, 
+				    binint_get_mass(k, kp, obj.id[1]) * units.mstar / FB_CONST_MSUN,
+				    binint_get_radii(k, kp, obj.id[0]) * units.l/RSUN, 
+				    binint_get_radii(k, kp, obj.id[1]) * units.l/RSUN,
+				    rho0_c,rho1_c,rho0_env, rho1_env, 
+				    binint_get_startype(k,kp, obj.id[0]), binint_get_startype(k,kp, obj.id[1]), 
+				    remnant_id, remnant_mass * units.mstar / FB_CONST_MSUN, remnant_radius*units.l/RSUN, 
+				    rhor_c, rhor_env,remnant_type, W*units.l/units.t/1.e5, rperi*units.l/RSUN);
+				    
+}
 
 /**
 * @brief do binary interaction (bin-bin or bin-single)
@@ -1643,12 +1928,12 @@ void binint_do(long k, long kp, double rperi, double w[4], double W, double rcm,
                             star[knew].se_radius = hier.obj[i]->R * cmc_units.l / BH_RADIUS_MULTIPLYER * units.l / RSUN;
                             star[knew].Eint = 0;
                             if(WRITE_BH_INFO && tempstar.se_k == 14 && star[knew].se_k == 14)
-                                parafprintf(bhmergerfile, "%.18g %s %g %ld %ld %g %g %g %g %g %g %g %g %g %g %g %g %g %g %g %g\n",
+                                parafprintf(bhmergerfile, "%.18g %s %g %ld %ld %g %g %g %g %g %g %g %g %g %g %g %g %g %g %g %g %g\n",
                                                           TotalTime, (isbinbin?"binary-binary":"binary-single"),
                                                           star_r[get_global_idx(knew)], hier.obj[i]->id[0],hier.obj[i]->id[nmerged], 
                                                           binint_get_mass(k, kp, hier.obj[i]->id[0]) * units.mstar / FB_CONST_MSUN, 
                                                           binint_get_mass(k, kp, hier.obj[i]->id[nmerged]) * units.mstar / FB_CONST_MSUN,
-                                                          binint_get_spins(k, kp, hier.obj[i]->id[0]), binint_get_spins(k, kp, hier.obj[i]->id[nmerged]), 
+					    binint_get_spins(k, kp, hier.obj[i]->id[0]), binint_get_spins(k, kp, hier.obj[i]->id[nmerged]), star[knew].id, 
                                                           star[knew].m*units.mstar/MSUN,hier.obj[i]->chi,hier.obj[i]->vkick[nmerged],
                                                           sqrt(-2*star_phi[get_global_idx(knew)]) * (units.l/units.t) / 1.0e5,
 														  hier.obj[i]->a_merger[nmerged]*cmc_units.l*units.l / FB_CONST_AU ,hier.obj[i]->e_merger[nmerged],
@@ -1681,9 +1966,19 @@ void binint_do(long k, long kp, double rperi, double w[4], double W, double rcm,
 						star[knew].id, star_m[get_global_idx(knew)],
 						star_r[get_global_idx(knew)],
 						*(hier.obj[i]), k, kp, star[knew].se_k);
+
+					if (WRITE_MORECOLL_INFO  && hier.obj[i]-> ncoll == 2){
+						/*Elena: Creating a file with additional collision information */
+						binint_log_morecollision(isbinbin?"binary-binary":"binary-single", star[knew].id,
+			  			star_m[get_global_idx(knew)], star[knew].rad, star[knew].se_k, star[knew].se_mc, 
+			  			star[knew].se_menv, star[knew].se_rc,star[knew].se_renv,*(hier.obj[i]),k,kp, W, rperi);
+			  			}
+
 				}
 				
 				star[knew].rad = star[knew].se_radius * RSUN / units.l;
+				
+				
 
 
 				/* track binding energy */
@@ -1731,13 +2026,13 @@ void binint_do(long k, long kp, double rperi, double w[4], double W, double rcm,
                             tempstar.se_radius = hier.obj[i]->obj[0]->R * cmc_units.l/ BH_RADIUS_MULTIPLYER * units.l / RSUN;
                             tempstar.Eint = 0;
                             if(WRITE_BH_INFO && tempstar2.se_k == 14 && tempstar.se_k == 14)
-                                parafprintf(bhmergerfile, "%.18g %s %g %ld %ld %g %g %g %g %g %g %g %g %g %g %g %g %g %g %g %g\n",
+                                parafprintf(bhmergerfile, "%.18g %s %g %ld %ld %g %g %g %g %g %g %g %g %g %g %g %g %g %g %g %g %g\n",
                                                           TotalTime, (isbinbin?"binary-binary":"binary-single"),
                                                           star_r[get_global_idx(knew)], hier.obj[i]->obj[0]->id[0],hier.obj[i]->obj[0]->id[nmerged], 
                                                           binint_get_mass(k, kp, hier.obj[i]->obj[0]->id[0]) * units.mstar / FB_CONST_MSUN, 
                                                           binint_get_mass(k, kp, hier.obj[i]->obj[0]->id[nmerged]) * units.mstar / FB_CONST_MSUN,
                                                           binint_get_spins(k, kp, hier.obj[i]->obj[0]->id[0]), binint_get_spins(k, kp, hier.obj[i]->obj[0]->id[nmerged]), 
-                                                          tempstar.m*units.mstar/MSUN,hier.obj[i]->obj[0]->chi,hier.obj[i]->obj[0]->vkick[nmerged],
+					    tempstar.id, tempstar.m*units.mstar/MSUN,hier.obj[i]->obj[0]->chi,hier.obj[i]->obj[0]->vkick[nmerged],
                                                           sqrt(-2*star_phi[get_global_idx(knew)]) * (units.l/units.t) / 1.0e5,
 														  hier.obj[i]->obj[0]->a_merger[nmerged]*cmc_units.l*units.l / FB_CONST_AU ,hier.obj[i]->obj[0]->e_merger[nmerged],
 														  hier.obj[i]->obj[0]->a_50M[nmerged]*cmc_units.l*units.l / FB_CONST_AU ,hier.obj[i]->obj[0]->e_50M[nmerged],
@@ -1783,6 +2078,13 @@ void binint_do(long k, long kp, double rperi, double w[4], double W, double rcm,
 								knew, star[knew].binind, binary[star[knew].binind].bse_kw[0], 
 								binary[star[knew].binind].bse_kw[1]);
 					}
+					
+
+					if (WRITE_MORECOLL_INFO  && hier.obj[i]->obj[0]->ncoll == 2){
+						/*Elena: Creating a file with additional collision information */
+						binint_log_morecollision(isbinbin?"binary-binary":"binary-single", binary[star[knew].binind].id1,
+			  			binary[star[knew].binind].m1, binary[star[knew].binind].rad1, binary[star[knew].binind].bse_kw[0], 							binary[star[knew].binind].bse_massc[0], binary[star[knew].binind].bse_menv[0], 							binary[star[knew].binind].bse_radc[0],binary[star[knew].binind].bse_renv[0],
+			  			*(hier.obj[i]->obj[0]),k,kp, W, rperi);}
 
 				}
 				if (hier.obj[i]->obj[1]->ncoll == 1) {
@@ -1813,13 +2115,13 @@ void binint_do(long k, long kp, double rperi, double w[4], double W, double rcm,
                             tempstar.se_radius = hier.obj[i]->obj[1]->R * cmc_units.l/ BH_RADIUS_MULTIPLYER * units.l / RSUN;
                             tempstar.Eint = 0;
                             if(WRITE_BH_INFO && tempstar2.se_k == 14 && tempstar.se_k == 14)
-                                parafprintf(bhmergerfile, "%.18g %s %g %ld %ld %g %g %g %g %g %g %g %g %g %g %g %g %g %g %g %g\n",
+                                parafprintf(bhmergerfile, "%.18g %s %g %ld %ld %g %g %g %g %g %g %g %g %g %g %g %g %g %g %g %g %g\n",
                                                           TotalTime, (isbinbin?"binary-binary":"binary-single"),
                                                           star_r[get_global_idx(knew)], hier.obj[i]->obj[1]->id[0],hier.obj[i]->obj[1]->id[nmerged], 
                                                           binint_get_mass(k, kp, hier.obj[i]->obj[1]->id[0]) * units.mstar / FB_CONST_MSUN, 
                                                           binint_get_mass(k, kp, hier.obj[i]->obj[1]->id[nmerged]) * units.mstar / FB_CONST_MSUN,
                                                           binint_get_spins(k, kp, hier.obj[i]->obj[1]->id[0]), binint_get_spins(k, kp, hier.obj[i]->obj[1]->id[nmerged]), 
-                                                          tempstar.m*units.mstar/MSUN,hier.obj[i]->obj[1]->chi,hier.obj[i]->obj[1]->vkick[nmerged],
+					    tempstar.id, tempstar.m*units.mstar/MSUN,hier.obj[i]->obj[1]->chi,hier.obj[i]->obj[1]->vkick[nmerged],
                                                           sqrt(-2*star_phi[get_global_idx(knew)]) * (units.l/units.t) / 1.0e5,
 														  hier.obj[i]->obj[1]->a_merger[nmerged]*cmc_units.l*units.l / FB_CONST_AU ,hier.obj[i]->obj[1]->e_merger[nmerged],
 														  hier.obj[i]->obj[1]->a_50M[nmerged]*cmc_units.l*units.l / FB_CONST_AU ,hier.obj[i]->obj[1]->e_50M[nmerged],
@@ -1861,9 +2163,16 @@ void binint_do(long k, long kp, double rperi, double w[4], double W, double rcm,
 						*(hier.obj[i]->obj[1]), k, kp, binary[star[knew].binind].bse_kw[1]);
 
 					if (binary[star[knew].binind].m2==0.)
-						dprintf("Zero mass remnant! Parameters: knew=%li, binind=%li, kw[0]=%i, kw[1]=%i\n",
+						dprintf("Zero mass remnant! Parameters: knew=%li binind=%li kw[0]=%i kw[1]=%i\n",
 								knew, star[knew].binind, binary[star[knew].binind].bse_kw[0],
 								binary[star[knew].binind].bse_kw[1]);
+
+					if (WRITE_MORECOLL_INFO  && hier.obj[i]->obj[1]->ncoll == 2){
+						/*Elena: Creating a file with additional collision information */
+						binint_log_morecollision(isbinbin?"binary-binary":"binary-single", binary[star[knew].binind].id2,
+			  			binary[star[knew].binind].m2, binary[star[knew].binind].rad2, binary[star[knew].binind].bse_kw[1], 							binary[star[knew].binind].bse_massc[1], binary[star[knew].binind].bse_menv[1], 
+			  			binary[star[knew].binind].bse_radc[1], binary[star[knew].binind].bse_renv[1],
+			  			*(hier.obj[i]->obj[1]),k,kp, W, rperi);}
 				}
 				
 				star_m[get_global_idx(knew)] = binary[star[knew].binind].m1 + binary[star[knew].binind].m2;
@@ -1948,13 +2257,13 @@ void binint_do(long k, long kp, double rperi, double w[4], double W, double rcm,
                             star[knewp].se_radius = hier.obj[i]->obj[sid]->R * cmc_units.l/ BH_RADIUS_MULTIPLYER * units.l / RSUN;
                             star[knewp].Eint = 0;
                             if(WRITE_BH_INFO && star[knewp].se_k == 14 && tempstar.se_k == 14 )
-                                parafprintf(bhmergerfile, "%.18g %s %g %ld %ld %g %g %g %g %g %g %g %g %g %g %g %g %g %g %g %g\n",
+                                parafprintf(bhmergerfile, "%.18g %s %g %ld %ld %g %g %g %g %g %g %g %g %g %g %g %g %g %g %g %g %g\n",
                                                           TotalTime, (isbinbin?"binary-binary":"binary-single"),
                                                           star_r[get_global_idx(knew)], hier.obj[i]->obj[sid]->id[0],hier.obj[i]->obj[sid]->id[nmerged], 
                                                           binint_get_mass(k, kp, hier.obj[i]->obj[sid]->id[0]) * units.mstar / FB_CONST_MSUN, 
                                                           binint_get_mass(k, kp, hier.obj[i]->obj[sid]->id[nmerged]) * units.mstar / FB_CONST_MSUN,
                                                           binint_get_spins(k, kp, hier.obj[i]->obj[sid]->id[0]), binint_get_spins(k, kp, hier.obj[i]->obj[sid]->id[nmerged]), 
-                                                          star[knewp].m*units.mstar/MSUN,hier.obj[i]->obj[sid]->chi,hier.obj[i]->obj[sid]->vkick[nmerged],
+					    star[knewp].id, star[knewp].m*units.mstar/MSUN,hier.obj[i]->obj[sid]->chi,hier.obj[i]->obj[sid]->vkick[nmerged],
                                                           sqrt(-2*star_phi[get_global_idx(knew)]) * (units.l/units.t) / 1.0e5,
 														  hier.obj[i]->obj[sid]->a_merger[nmerged]*cmc_units.l*units.l / FB_CONST_AU ,hier.obj[i]->obj[sid]->e_merger[nmerged],
 														  hier.obj[i]->obj[sid]->a_50M[nmerged]*cmc_units.l*units.l / FB_CONST_AU ,hier.obj[i]->obj[sid]->e_50M[nmerged],
@@ -1983,9 +2292,18 @@ void binint_do(long k, long kp, double rperi, double w[4], double W, double rcm,
 						star[knewp].id, star_m[get_global_idx(knewp)],
 						star_r[get_global_idx(knewp)],
 						*(hier.obj[i]->obj[sid]), k, kp, star[knewp].se_k);
+
+					if (WRITE_MORECOLL_INFO  && hier.obj[i]->obj[sid]->ncoll == 2){
+						/*Elena: Creating a file with additional collision information */
+						binint_log_morecollision(isbinbin?"binary-binary":"binary-single", star[knewp].id,
+			  			star_m[get_global_idx(knewp)], star[knewp].rad, star[knewp].se_k, star[knewp].se_mc, 
+			  			star[knewp].se_menv, star[knewp].se_rc,star[knewp].se_renv,*(hier.obj[i]->obj[sid]),k,kp, W, rperi);}	
+		
 				}
 				/* radius */
 				star[knewp].rad = star[knewp].se_radius * RSUN / units.l;
+				
+				
 
 				/***************************/
 				/* set binary's properties */
@@ -2031,13 +2349,13 @@ void binint_do(long k, long kp, double rperi, double w[4], double W, double rcm,
                             tempstar.se_radius = hier.obj[i]->obj[bid]->obj[0]->R * cmc_units.l/ BH_RADIUS_MULTIPLYER * units.l / RSUN;
                             tempstar.Eint = 0;
                             if(WRITE_BH_INFO && tempstar2.se_k == 14 && tempstar.se_k == 14)
-                                parafprintf(bhmergerfile, "%.18g %s %g %ld %ld %g %g %g %g %g %g %g %g %g %g %g %g %g %g %g %g\n",
+                                parafprintf(bhmergerfile, "%.18g %s %g %ld %ld %g %g %g %g %g %g %g %g %g %g %g %g %g %g %g %g %g\n",
                                                           TotalTime, (isbinbin?"binary-binary":"binary-single"),
                                                           star_r[get_global_idx(knew)], hier.obj[i]->obj[bid]->obj[0]->id[0],hier.obj[i]->obj[bid]->obj[0]->id[nmerged], 
                                                           binint_get_mass(k, kp, hier.obj[i]->obj[bid]->obj[0]->id[0]) * units.mstar / FB_CONST_MSUN, 
                                                           binint_get_mass(k, kp, hier.obj[i]->obj[bid]->obj[0]->id[nmerged]) * units.mstar / FB_CONST_MSUN,
                                                           binint_get_spins(k, kp, hier.obj[i]->obj[bid]->obj[0]->id[0]), binint_get_spins(k, kp, hier.obj[i]->obj[bid]->obj[0]->id[nmerged]), 
-                                                          tempstar.m*units.mstar/MSUN,hier.obj[i]->obj[bid]->obj[0]->chi,hier.obj[i]->obj[bid]->obj[0]->vkick[nmerged],
+					    tempstar.id, tempstar.m*units.mstar/MSUN,hier.obj[i]->obj[bid]->obj[0]->chi,hier.obj[i]->obj[bid]->obj[0]->vkick[nmerged],
                                                           sqrt(-2*star_phi[get_global_idx(knew)]) * (units.l/units.t) / 1.0e5,
 														  hier.obj[i]->obj[bid]->obj[0]->a_merger[nmerged]*cmc_units.l*units.l / FB_CONST_AU ,hier.obj[i]->obj[bid]->obj[0]->e_merger[nmerged],
 														  hier.obj[i]->obj[bid]->obj[0]->a_50M[nmerged]*cmc_units.l*units.l / FB_CONST_AU ,hier.obj[i]->obj[bid]->obj[0]->e_50M[nmerged],
@@ -2070,11 +2388,22 @@ void binint_do(long k, long kp, double rperi, double w[4], double W, double rcm,
 						dprintf("dynhelp_merge5: TT=%.18g vs[0]=%.18g vs[1]=%.18g vs[2]=%.18g vs[3]=%.18g vs[4]=%.18g vs[5]=%.18g vs[6]=%.18g VK0=%.18g star_id=%ld\n",TotalTime,vs[0],vs[1],vs[2],vs[3],vs[4],vs[5],vs[6],VK0,binary[star[knew].binind].id1);
 					}
 					/* log collision */
+					
 					binint_log_collision(isbinbin?"binary-binary":"binary-single",
 						binary[star[knew].binind].id1,
 						binary[star[knew].binind].m1,
 						star_r[get_global_idx(knew)],
 						*(hier.obj[i]->obj[bid]->obj[0]), k, kp, binary[star[knew].binind].bse_kw[0]);
+
+					if (WRITE_MORECOLL_INFO  && hier.obj[i]->obj[bid]->obj[0]->ncoll == 2){
+						/*Elena: Creating a file with additional collision information */
+						binint_log_morecollision(isbinbin?"binary-binary":"binary-single", binary[star[knew].binind].id1,
+			  			binary[star[knew].binind].m1, binary[star[knew].binind].rad1, 
+			  			binary[star[knew].binind].bse_kw[0], 
+			  			binary[star[knew].binind].bse_massc[0], binary[star[knew].binind].bse_menv[0], 
+			  			binary[star[knew].binind].bse_radc[0], binary[star[knew].binind].bse_renv[0],
+			  			*(hier.obj[i]->obj[bid]->obj[0]),k,kp, W, rperi);}
+			  				
 				}
 				if (hier.obj[i]->obj[bid]->obj[1]->ncoll == 1) {
 					binary[star[knew].binind].id2 = hier.obj[i]->obj[bid]->obj[1]->id[0];
@@ -2104,13 +2433,13 @@ void binint_do(long k, long kp, double rperi, double w[4], double W, double rcm,
                             tempstar.se_radius = hier.obj[i]->obj[bid]->obj[1]->R * cmc_units.l/ BH_RADIUS_MULTIPLYER * units.l / RSUN;
                             tempstar.Eint = 0;
                             if(WRITE_BH_INFO && tempstar2.se_k == 14 && tempstar.se_k == 14)
-                                parafprintf(bhmergerfile, "%.18g %s %g %ld %ld %g %g %g %g %g %g %g %g %g %g %g %g %g %g %g %g\n",
+                                parafprintf(bhmergerfile, "%.18g %s %g %ld %ld %g %g %g %g %g %g %g %g %g %g %g %g %g %g %g %g %g\n",
                                                           TotalTime, (isbinbin?"binary-binary":"binary-single"),
                                                           star_r[get_global_idx(knew)], hier.obj[i]->obj[bid]->obj[1]->id[0],hier.obj[i]->obj[bid]->obj[1]->id[nmerged], 
                                                           binint_get_mass(k, kp, hier.obj[i]->obj[bid]->obj[1]->id[0]) * units.mstar / FB_CONST_MSUN, 
                                                           binint_get_mass(k, kp, hier.obj[i]->obj[bid]->obj[1]->id[nmerged]) * units.mstar / FB_CONST_MSUN,
                                                           binint_get_spins(k, kp, hier.obj[i]->obj[bid]->obj[1]->id[0]), binint_get_spins(k, kp, hier.obj[i]->obj[bid]->obj[1]->id[nmerged]), 
-                                                          tempstar.m*units.mstar/MSUN,hier.obj[i]->obj[bid]->obj[1]->chi,hier.obj[i]->obj[bid]->obj[1]->vkick[nmerged],
+					    tempstar.id, tempstar.m*units.mstar/MSUN,hier.obj[i]->obj[bid]->obj[1]->chi,hier.obj[i]->obj[bid]->obj[1]->vkick[nmerged],
                                                           sqrt(-2*star_phi[get_global_idx(knew)]) * (units.l/units.t) / 1.0e5,
 														  hier.obj[i]->obj[bid]->obj[1]->a_merger[nmerged]*cmc_units.l*units.l / FB_CONST_AU ,hier.obj[i]->obj[bid]->obj[1]->e_merger[nmerged],
 														  hier.obj[i]->obj[bid]->obj[1]->a_50M[nmerged]*cmc_units.l*units.l / FB_CONST_AU ,hier.obj[i]->obj[bid]->obj[1]->e_50M[nmerged],
@@ -2144,6 +2473,15 @@ void binint_do(long k, long kp, double rperi, double w[4], double W, double rcm,
 						binary[star[knew].binind].m2, 
 						star_r[get_global_idx(knew)],
 						*(hier.obj[i]->obj[bid]->obj[1]), k, kp, binary[star[knew].binind].bse_kw[1]);
+
+					if (WRITE_MORECOLL_INFO  && hier.obj[i]->obj[bid]->obj[1]->ncoll == 2){
+						/*Elena: Creating a file with additional collision information */
+						binint_log_morecollision(isbinbin?"binary-binary":"binary-single", 
+						binary[star[knew].binind].id2, binary[star[knew].binind].m2,
+			  			binary[star[knew].binind].rad2, binary[star[knew].binind].bse_kw[1],
+			  			binary[star[knew].binind].bse_massc[1], binary[star[knew].binind].bse_menv[1], 							binary[star[knew].binind].bse_radc[1], binary[star[knew].binind].bse_renv[1],
+			  			*(hier.obj[i]->obj[bid]->obj[1]),k,kp, W, rperi);}	
+						
 				}
 
 				star_m[get_global_idx(knew)] = binary[star[knew].binind].m1 + binary[star[knew].binind].m2;
@@ -2911,8 +3249,8 @@ void binary_bh_merger(long k, long kb, long knew, int kprev0, int kprev1, struct
 	star[knew].se_bhspin = afinal;
 
     if(WRITE_BH_INFO)
-        parafprintf(bhmergerfile, "%.18g %s %g %ld %ld %g %g %g %g %g %g %g %g %g %g -100 -100 -100 -100 -100 -100\n", TotalTime, "isolat-binary",
-                                        star_r[get_global_idx(knew)], binary[kb].id1,binary[kb].id2, m1,m2,chi1,chi2,
+        parafprintf(bhmergerfile, "%.18g %s %g %ld %ld %g %g %g %g %g %g %g %g %g %g %g -100 -100 -100 -100 -100 -100\n", TotalTime, "isolat-binary",
+		    star_r[get_global_idx(knew)], binary[kb].id1,binary[kb].id2, m1,m2,chi1,chi2,star[knew].id,
                                         (m1+m2)*mass_frac, afinal,vk, 
                                         sqrt(-2*star_phi[get_global_idx(knew)])*(units.l/units.t) / 1.0e5, 
                                         binary[kb].a*units.l/AU,binary[kb].e);

--- a/src/cmc/cmc_io.c
+++ b/src/cmc/cmc_io.c
@@ -1377,6 +1377,10 @@ if(myid==0) {
                                 PRINT_PARSED(PARAMDOC_BSE_PTS3);
                                 sscanf(values, "%lf", &BSE_PTS3);
                                 parsed.BSE_PTS3 = 1;
+			} else if (strcmp(parameter_name, "PTS1_HIGHMASS_CUTOFF")== 0) {
+                                PRINT_PARSED(PARAMDOC_BSE_PTS1_HIGHMASS_CUTOFF);
+                                sscanf(values, "%lf", &BSE_PTS1_HIGHMASS_CUTOFF);
+                                parsed.BSE_PTS1_HIGHMASS_CUTOFF = 1;	
 			} else if (strcmp(parameter_name, "WINDFLAG")==0) {
 				PRINT_PARSED(PARAMDOC_BSE_WINDFLAG);
 				sscanf(values, "%d", &BSE_WINDFLAG);
@@ -1733,6 +1737,9 @@ if(myid==0) {
         CHECK_PARSED(BSE_PTS2, 0.01, PARAMDOC_BSE_PTS2);
         //                 pts3 - HG, HeMS            (default=0.02)
         CHECK_PARSED(BSE_PTS3, 0.02, PARAMDOC_BSE_PTS3);
+
+	// For any stars with ZAMS masses above PTS1_HIGHMASS_CUTOFF, decrease PTS1 by 10x
+        CHECK_PARSED(BSE_PTS1_HIGHMASS_CUTOFF, 5, PARAMDOC_BSE_PTS1_HIGHMASS_CUTOFF);
 
         // windflag sets the wind prescription
         // windflag=0: stock BSE// windflag=1: StarTrack 2008

--- a/src/cmc/cmc_io.c
+++ b/src/cmc/cmc_io.c
@@ -708,7 +708,11 @@ void PrintParaFileOutput(void)
     if (WRITE_MOREPULSAR_INFO)
         mpi_para_file_write(mpi_morepulsarfile_wrbuf, &mpi_morepulsarfile_len, &mpi_morepulsarfile_ofst_total, &mpi_morepulsarfile);
 
-    /* Meagan's 3bb files */
+/*Elena  */ 
+    if (WRITE_MORECOLL_INFO){
+        mpi_para_file_write(mpi_morecollfile_wrbuf, &mpi_morecollfile_len, &mpi_morecollfile_ofst_total, &mpi_morecollfile);  
+    }
+/* Meagan's 3bb files */
     if (WRITE_BH_INFO){
         mpi_para_file_write(mpi_newbhfile_wrbuf, &mpi_newbhfile_len, &mpi_newbhfile_ofst_total, &mpi_newbhfile);
         mpi_para_file_write(mpi_bhmergerfile_wrbuf, &mpi_bhmergerfile_len, &mpi_bhmergerfile_ofst_total, &mpi_bhmergerfile);
@@ -1336,6 +1340,10 @@ if(myid==0) {
                                 PRINT_PARSED(PARAMDOC_WRITE_MOREPULSAR_INFO);
                                 sscanf(values, "%i", &WRITE_MOREPULSAR_INFO);
                                 parsed.WRITE_MOREPULSAR_INFO = 1;
+                        } else if (strcmp(parameter_name, "WRITE_MORECOLL_INFO")== 0) {
+                                PRINT_PARSED(PARAMDOC_WRITE_MORECOLL_INFO);
+                                sscanf(values, "%i", &WRITE_MORECOLL_INFO);
+                                parsed.WRITE_MORECOLL_INFO = 1;
 			} else if (strcmp(parameter_name, "CALCULATE10")== 0) {
 				PRINT_PARSED(PARAMDOC_CALCULATE10);
 				sscanf(values, "%i", &CALCULATE10);
@@ -1369,10 +1377,6 @@ if(myid==0) {
                                 PRINT_PARSED(PARAMDOC_BSE_PTS3);
                                 sscanf(values, "%lf", &BSE_PTS3);
                                 parsed.BSE_PTS3 = 1;
-                        } else if (strcmp(parameter_name, "PTS1_HIGHMASS_CUTOFF")== 0) {
-                                PRINT_PARSED(PARAMDOC_BSE_PTS1_HIGHMASS_CUTOFF);
-                                sscanf(values, "%lf", &BSE_PTS1_HIGHMASS_CUTOFF);
-                                parsed.BSE_PTS1_HIGHMASS_CUTOFF = 1;
 			} else if (strcmp(parameter_name, "WINDFLAG")==0) {
 				PRINT_PARSED(PARAMDOC_BSE_WINDFLAG);
 				sscanf(values, "%d", &BSE_WINDFLAG);
@@ -1643,6 +1647,7 @@ if(myid==0) {
     CHECK_PARSED(WRITE_EXTRA_CORE_INFO, 0, PARAMDOC_WRITE_EXTRA_CORE_INFO);
     CHECK_PARSED(WRITE_PULSAR_INFO, 0, PARAMDOC_WRITE_PULSAR_INFO);
     CHECK_PARSED(WRITE_MOREPULSAR_INFO, 0, PARAMDOC_WRITE_MOREPULSAR_INFO);
+    CHECK_PARSED(WRITE_MORECOLL_INFO, 0, PARAMDOC_WRITE_MORECOLL_INFO);
 	CHECK_PARSED(CALCULATE10, 0, PARAMDOC_CALCULATE10);
 	CHECK_PARSED(WIND_FACTOR, 1.0, PARAMDOC_WIND_FACTOR);
 	CHECK_PARSED(TIDAL_TREATMENT, 0, PARAMDOC_TIDAL_TREATMENT);
@@ -1728,9 +1733,6 @@ if(myid==0) {
         CHECK_PARSED(BSE_PTS2, 0.01, PARAMDOC_BSE_PTS2);
         //                 pts3 - HG, HeMS            (default=0.02)
         CHECK_PARSED(BSE_PTS3, 0.02, PARAMDOC_BSE_PTS3);
-
-        // For any stars with ZAMS masses above PTS1_HIGHMASS_CUTOFF, decrease PTS1 by 10x
-        CHECK_PARSED(BSE_PTS1_HIGHMASS_CUTOFF, 5, PARAMDOC_BSE_PTS1_HIGHMASS_CUTOFF);
 
         // windflag sets the wind prescription
         // windflag=0: stock BSE// windflag=1: StarTrack 2008
@@ -2425,8 +2427,14 @@ MPI: In the parallel version, IO is done in the following way. Some files requir
 		MPI_File_set_size(mpi_morepulsarfile, 0);
     }
 
-
-	//MPI: Headers are written out only by the root node.
+    /* Elena */
+    if (WRITE_MORECOLL_INFO){
+        sprintf(outfile, "%s.morecoll.dat", outprefix);
+        MPI_File_open(MPI_COMM_WORLD, outfile, MPI_MODE_CREATE | MPI_MODE_WRONLY, MPI_INFO_NULL, &mpi_morecollfile);
+        if(RESTART_TCOUNT <= 0)
+        	MPI_File_set_size(mpi_morecollfile, 0);
+    }	
+//MPI: Headers are written out only by the root node.
    // print header
     if(RESTART_TCOUNT <= 0){
 		pararootfprintf(escfile, "#1:tcount #2:t #3:m[MSUN] #4:r #5:vr #6:vt #7:r_peri #8:r_apo #9:Rtidal #10:phi_rtidal #11:phi_zero #12:E #13:J #14:id #15:binflag #16:m0[MSUN] #17:m1[MSUN] #18:id0 #19:id1 #20:a #21:e #22:startype #23:bin_startype0 #24:bin_startype1 #25:rad0 #26:rad1 #27:tb #28:lum0 #29:lum1 #30:massc0 #31:massc1 #32:radc0 #33:radc1 #34:menv0 #35:menv1 #36:renv0 #37:renv1 #38:tms0 #39:tms1 #40:dmdt0 #41:dmdt1 #42:radrol0 #43:radrol1 #44:ospin0 #45:ospin1 #46:B0 #47:B1 #48:formation0 #49:formation1 #50:bacc0 #51:bacc1 #52:tacc0 $53:tacc1 #54:mass0_0 #55:mass0_1 #56:epoch0 #57:epoch1 #58:bhspin #59:bhspin1 #60:bhspin2 #61:ospin #62:B #63:formation\n");
@@ -2461,7 +2469,7 @@ MPI: In the parallel version, IO is done in the following way. Some files requir
 		// print header
 		if (WRITE_BH_INFO)
 			pararootfprintf(newbhfile,"#1:time #2:r #3.binary? #4:ID #5:zams_m #6:m_progenitor #7:bh mass #8:bh_spin #9:birth-kick(km/s) #10-25:vsarray\n");
-			pararootfprintf(bhmergerfile,"#1:time #2:type #3.r #4:id1 #5:id2 #6:m1[MSUN] #7:m2[MSUN] #8:spin1 #9:spin2 #10:m_final[MSUN] #11:spin_final #12:vkick[km/s] #13:v_esc[km/s] #14:a_final[AU] #15:e_final #16:a_50M[AU] #17:e_50 #18:a_100M[AU] #19:e_100M #20:a_500M[AU] #21:e_500M\n");
+			pararootfprintf(bhmergerfile,"#1:time #2:type #3.r #4:id1 #5:id2 #6:m1[MSUN] #7:m2[MSUN] #8:spin1 #9:spin2 #10:final_id #11:m_final[MSUN] #12:spin_final #13:vkick[km/s] #14:v_esc[km/s] #15:a_final[AU] #16:e_final #17:a_50M[AU] #18:e_50 #19:a_100M[AU] #20:e_100M #21:a_500M[AU] #22:e_500M\n");
 			pararootfprintf(bhmergerfile,"#NOTE: if repeated mergers occur in fewbody (binary-single or binary-binary), the initial masses will be wrong; check collision.log\n");
 	//"#1:tcount  #2:TotalTime  #3:bh  #4:bh_single  #5:bh_binary  #6:bh-bh  #7:bh-ns  #8:bh-wd  #9:bh-star  #10:bh-nonbh  #11:fb_bh  #12:bh_tot  #13:bh_single_tot  #14:bh_binary_tot  #15:bh-bh_tot  #16:bh-ns_tot  #17:bh-wd_tot  #18:bh-star_tot  #19:bh-nonbh_tot  #20:fb_bh_tot\n");
 
@@ -2471,8 +2479,10 @@ MPI: In the parallel version, IO is done in the following way. Some files requir
                 /* print header */ //Shi
                 if (WRITE_MOREPULSAR_INFO)
                		pararootfprintf(morepulsarfile,"#1:tcount #2:TotalTime #3:binflag #4:id0 #5:id1 #6:m0[MSUN] #7:m1[MSUN] #8:B0[G] #9:B1[G] #10:P0[sec] #11:P1[sec] #12:startype0 #13:startype1 #14:a[AU] #15:ecc #16:radrol0 #17:radrol1 #18:dmdt0 #19:dmdt1 #20:r #21:vr #22:vt #23:bacc0 #24:bacc1 #25:tacc0 #26:tacc1 #27:formation0 #28:formation1\n");
-
-	} /*if(RESTART_TCOUNT == 0)*/
+                /* print header */ //Elena
+                if (WRITE_MORECOLL_INFO)
+                        pararootfprintf(morecollfile,"#1:TotalTime #2:collision-type #3:id0 #4:id1 #5:m0[MSUN] #6:m1[MSUN] #7:rad1[RSUN] #8:rad2[RSUN] #9:rho0_c[MSUN/RSUN^3] #10:rho1_c[MSUN/RSUN^3] #11:rho0_env[MSUN/RSUN^3] #12:rho1_env[MSUN/RSUN^3] #13:kstar0 #14:kstar1 #15:idr #16:mr[MSUN] #17:radr[RSUN] #18:rhor_c[MSUN/RSUN^3] #19:rhor_env[MSUN/RSUN^3] #20:kstar, #21:vinf[km/s], #22:rperi\n");
+	}/*if(RESTART_TCOUNT == 0)*/
 
 }
 
@@ -2556,7 +2566,12 @@ void close_node_buffers(void)
     if (WRITE_MOREPULSAR_INFO){
     	fclose(morepulsarfile);
     }
+    //Elena 
+    if (WRITE_MORECOLL_INFO){
+        fclose(morecollfile);
+    }   
 }
+
 
 /**
 * @brief Closes the MPI file pointers - of files which require writing only by the all nodes.
@@ -2594,7 +2609,11 @@ void mpi_close_node_buffers(void)
     if (WRITE_MOREPULSAR_INFO){
     	MPI_File_close(&mpi_morepulsarfile);
     }
-
+   
+    //Elena
+    if (WRITE_MORECOLL_INFO){
+        MPI_File_close(&mpi_morecollfile);
+                }
 }
 
 /**
@@ -3574,6 +3593,7 @@ typedef struct{
     long long s_mpi_relaxationfile_len;
     long long s_mpi_pulsarfile_len;
     long long s_mpi_morepulsarfile_len;
+    long long s_mpi_morecollfile_len;
     long long s_mpi_triplefile_len;
     long long s_mpi_bhmergerfile_len;
     long long s_mpi_logfile_ofst_total;
@@ -3587,6 +3607,7 @@ typedef struct{
     long long s_mpi_relaxationfile_ofst_total;
     long long s_mpi_pulsarfile_ofst_total;
     long long s_mpi_morepulsarfile_ofst_total;
+    long long s_mpi_morecollfile_ofst_total;
     long long s_mpi_triplefile_ofst_total;
     long long s_mpi_bhmergerfile_ofst_total;
 
@@ -3629,6 +3650,7 @@ void save_global_vars(restart_struct_t *rest){
 	rest->s_mpi_relaxationfile_len             =mpi_relaxationfile_len;
 	rest->s_mpi_pulsarfile_len                 =mpi_pulsarfile_len;
         rest->s_mpi_morepulsarfile_len             =mpi_morepulsarfile_len;
+        rest->s_mpi_morecollfile_len               =mpi_morecollfile_len;        
         rest->s_mpi_triplefile_len                 =mpi_triplefile_len;
 	rest->s_mpi_bhmergerfile_len               =mpi_bhmergerfile_len;
 	rest->s_mpi_logfile_ofst_total             =mpi_logfile_ofst_total;
@@ -3642,6 +3664,7 @@ void save_global_vars(restart_struct_t *rest){
 	rest->s_mpi_relaxationfile_ofst_total      =mpi_relaxationfile_ofst_total;
 	rest->s_mpi_pulsarfile_ofst_total          =mpi_pulsarfile_ofst_total;
         rest->s_mpi_morepulsarfile_ofst_total      =mpi_morepulsarfile_ofst_total;
+        rest->s_mpi_morecollfile_len               =mpi_morecollfile_len;        
         rest->s_mpi_triplefile_ofst_total          =mpi_triplefile_ofst_total;
 	rest->s_mpi_bhmergerfile_ofst_total        =mpi_bhmergerfile_ofst_total;
 
@@ -3684,6 +3707,7 @@ void load_global_vars(restart_struct_t *rest){
 	mpi_relaxationfile_len             =rest->s_mpi_relaxationfile_len;
 	mpi_pulsarfile_len                 =rest->s_mpi_pulsarfile_len;
         mpi_morepulsarfile_len             =rest->s_mpi_morepulsarfile_len;
+        mpi_morecollfile_len               =rest->s_mpi_morecollfile_len;
         mpi_triplefile_len                 =rest->s_mpi_triplefile_len;
 	mpi_bhmergerfile_len               =rest->s_mpi_bhmergerfile_len;
 	mpi_logfile_ofst_total             =rest->s_mpi_logfile_ofst_total;
@@ -3697,6 +3721,7 @@ void load_global_vars(restart_struct_t *rest){
 	mpi_relaxationfile_ofst_total      =rest->s_mpi_relaxationfile_ofst_total;
 	mpi_pulsarfile_ofst_total          =rest->s_mpi_pulsarfile_ofst_total;
         mpi_morepulsarfile_ofst_total      =rest->s_mpi_morepulsarfile_ofst_total;
+        mpi_morecollfile_ofst_total        =rest->s_mpi_morecollfile_ofst_total;        
         mpi_triplefile_ofst_total          =rest->s_mpi_triplefile_ofst_total;
 	mpi_bhmergerfile_ofst_total        =rest->s_mpi_bhmergerfile_ofst_total;
 
@@ -3865,6 +3890,9 @@ void load_restart_file(){
 	if(WRITE_MOREPULSAR_INFO){
              MPI_File_seek(mpi_morepulsarfile,mpi_morepulsarfile_ofst_total,MPI_SEEK_SET);
         }
+        if(WRITE_MORECOLL_INFO){
+             MPI_File_seek(mpi_morecollfile,mpi_morecollfile_ofst_total,MPI_SEEK_SET);
+        }
     } else{
         mpi_logfile_len=0;
         mpi_escfile_len=0;
@@ -3876,6 +3904,7 @@ void load_restart_file(){
         mpi_relaxationfile_len=0;
         mpi_pulsarfile_len=0;
 	mpi_morepulsarfile_len=0;
+	mpi_morecollfile_len=0;
 	mpi_triplefile_len=0;
 	mpi_newbhfile_len=0;
 	mpi_bhmergerfile_len=0;
@@ -3891,6 +3920,7 @@ void load_restart_file(){
         mpi_relaxationfile_ofst_total=0;
         mpi_pulsarfile_ofst_total=0;
 	mpi_morepulsarfile_ofst_total=0;
+	mpi_morecollfile_ofst_total=0;
 	mpi_triplefile_ofst_total=0;
 	mpi_newbhfile_ofst_total=0;
 	mpi_bhmergerfile_ofst_total=0;

--- a/src/cmc/cmc_sscollision.c
+++ b/src/cmc/cmc_sscollision.c
@@ -247,14 +247,43 @@ void sscollision_do(long k, long kp, double rperimax, double w[4], double W, dou
 
 
                         /* log collision */
-                        parafprintf(collisionfile, "t=%g single-single idm=%ld(mm=%g) id1=%ld(m1=%g):id2=%ld(m2=%g) (r=%g) typem=%d type1=%d type2=%d b[RSUN]=%g vinf[km/s]=%g rad1=%g rad2=%g rperi=%g coll_mult=%g\n",
+			/* Elena: changing format of this output*/
+
+                        parafprintf(collisionfile, "t=%g single-single idm=%ld(mm=%g) id1=%ld(m1=%g):id2=%ld(m2=%g) (r=%g) typem=%d type1=%d type2=%d rad1[RSUN]=%g rad2[RSUN]=%g b[RSUN]=%g vinf[km/s]=%g rperi=%g coll_mult=%g\n",
                                 TotalTime,
                                 star[knew].id, star_m[get_global_idx(knew)] * units.mstar / FB_CONST_MSUN,
                                 star[k].id, mass_k * units.mstar / FB_CONST_MSUN,
                                 star[kp].id, mass_kp * units.mstar / FB_CONST_MSUN,
                                 star_r[get_global_idx(knew)], star[knew].se_k, star[k].se_k, star[kp].se_k,
-                    b*units.l/RSUN,W*units.l/units.t/1.e5, star[k].rad*units.l/RSUN, star[kp].rad*units.l/RSUN, rperi*units.l/RSUN, collisions_multiple_hold);
+				star[k].rad*units.l/RSUN, star[kp].rad*units.l/RSUN,
+                    b*units.l/RSUN,W*units.l/units.t/1.e5, rperi*units.l/RSUN, collisions_multiple_hold);
+                    
+			/* units should be okay already */
+			double rho0_c = (star[k].se_mc  ) / ((4/3)* PI * pow((star[k].se_rc  ),3));
+			double rho1_c = (star[kp].se_mc ) / ((4/3)* PI * pow((star[kp].se_rc ),3));
+			double rho0_env = (star[k].se_menv  ) / ((4/3)* PI * pow((star[k].se_renv ),3));
+			double rho1_env = (star[kp].se_menv  ) / ((4/3)* PI *pow((star[kp].se_renv  ),3));
+			double rhor_c = (star[knew].se_mc ) / ((4/3)* PI *pow((star[knew].se_rc ),3));
+			double rhor_env = (star[knew].se_menv ) / ((4/3)* PI * pow((star[knew].se_renv ),3));
 
+			if(isnan(rho0_c)){rho0_c = -100;}
+			if(isnan(rho1_c)){rho1_c = -100;}
+			if(isnan(rhor_c)){rhor_c = -100;}
+			if(isnan(rho0_env)){rho0_env = -100;}
+			if(isnan(rho1_env)){rho1_env = -100;}
+			if(isnan(rhor_env)){rhor_env = -100;}
+			
+			// Elena: For some stars, COSMIC assigns default renv and menv values of e-10, which makes my densities exactly 3.1831e-19. I 				will change these vales to output a -100 intead, since it is not physical //
+	
+			if(rho0_env >= 1.0e19){rho0_env = -100;}
+			if(rho1_env >= 1.0e19){rho1_env = -100;}
+			if(rhor_env >= 1.0e19){rhor_env = -100;}
+					
+			/*Elena: Creating a file with additional collision information */
+			parafprintf(morecollfile, "%g single-single %ld %ld %g %g %g %g %g %g %g %g %d %d %ld %g %g %g %g %d %g %g\n",
+				    TotalTime, star[k].id, star[kp].id, mass_k * units.mstar / FB_CONST_MSUN, mass_kp * units.mstar / FB_CONST_MSUN,
+				    star[k].rad*units.l/RSUN, star[kp].rad*units.l/RSUN,rho0_c,rho1_c,rho0_env, rho1_env, star[k].se_k, star[kp].se_k,
+				    star[knew].id, star_m[get_global_idx(knew)] * units.mstar / FB_CONST_MSUN, star[knew].rad*units.l/RSUN, rhor_c, 				             rhor_env, star[knew].se_k, W*units.l/units.t/1.e5, rperi*units.l/RSUN);
                         /* destroy two progenitors */
                         destroy_obj(k);
                         destroy_obj(kp);
@@ -424,13 +453,42 @@ void sscollision_do(long k, long kp, double rperimax, double w[4], double W, dou
 
 
                         /* log collision */
-                        parafprintf(collisionfile, "t=%g single-single idm=%ld(mm=%g) id1=%ld(m1=%g):id2=%ld(m2=%g) (r=%g) typem=%d type1=%d type2=%d b[RSUN]=%g vinf[km/s]=%g rad1=%g rad2=%g rperi=%g coll_mult=%g\n",
+                        parafprintf(collisionfile, "t=%g single-single idm=%ld(mm=%g) id1=%ld(m1=%g):id2=%ld(m2=%g) (r=%g) typem=%d type1=%d type2=%d rad1[RSUN]=%g rad2[RSUN]=%g b[RSUN]=%g vinf[km/s]=%g rperi=%g coll_mult=%g\n",
                                 TotalTime,
                                 star[knew].id, star_m[get_global_idx(knew)] * units.mstar / FB_CONST_MSUN,
                                 star[k].id, mass_k * units.mstar / FB_CONST_MSUN,
                                 star[kp].id, mass_kp * units.mstar / FB_CONST_MSUN,
                                 star_r[get_global_idx(knew)], star[knew].se_k, star[k].se_k, star[kp].se_k,
-                    b*units.l/RSUN,W*units.l/units.t/1.e5, star[k].rad*units.l/RSUN, star[kp].rad*units.l/RSUN, rperi*units.l/RSUN, collisions_multiple_hold);
+			        star[k].rad*units.l/RSUN, star[kp].rad*units.l/RSUN,
+                    b*units.l/RSUN,W*units.l/units.t/1.e5,  rperi*units.l/RSUN, collisions_multiple_hold);
+
+			/*Elena: Creating a file with additional collision information */
+			double rho0_c = (star[k].se_mc ) / ((4/3)* PI * pow((star[k].se_rc ),3));
+			double rho1_c = (star[kp].se_mc ) / ((4/3)* PI * pow((star[kp].se_rc ),3));
+			double rho0_env = (star[k].se_menv ) / ((4/3)* PI * pow((star[k].se_renv ),3));
+			double rho1_env = (star[kp].se_menv ) / ((4/3)* PI *pow((star[kp].se_renv ),3));
+			double rhor_c = (star[knew].se_mc ) / ((4/3)* PI *pow((star[knew].se_rc ),3));
+			double rhor_env =(star[knew].se_menv ) /((4/3)* PI * pow((star[knew].se_renv ),3));
+			
+			
+			if(isnan(rho0_c)){rho0_c = -100;}
+			if(isnan(rho1_c)){rho1_c = -100;}
+			if(isnan(rhor_c)){rhor_c = -100;}
+			if(isnan(rho0_env)){rho0_env = -100;}
+			if(isnan(rho1_env)){rho1_env = -100;}
+			if(isnan(rhor_env)){rhor_env = -100;}
+			
+			// Elena: For some stars, COSMIC assigns default renv and menv values of of e-10, which makes my densities exactly 3.1831e-19. I 				will change these vales to output a -100 intead, since it is not physical //
+	
+
+			if(rho0_env >= 1.0e19){rho0_env = -100;}
+			if(rho1_env >= 1.0e19){rho1_env = -100;}
+			if(rhor_env >= 1.0e19){rhor_env = -100;}
+	
+			parafprintf(morecollfile, "%g single-single %ld %ld %g %g %g %g %g %g %g %g %d %d %ld %g %g %g %g %d %g %g\n",
+				    TotalTime, star[k].id, star[kp].id, mass_k * units.mstar / FB_CONST_MSUN, mass_kp * units.mstar / FB_CONST_MSUN,
+				    star[k].rad*units.l/RSUN, star[kp].rad*units.l/RSUN,rho0_c,rho1_c,rho0_env, rho1_env, star[k].se_k, star[kp].se_k,
+				    star[knew].id, star_m[get_global_idx(knew)] * units.mstar / FB_CONST_MSUN, star[knew].rad*units.l/RSUN, rhor_c, 					    rhor_env, star[knew].se_k, W*units.l/units.t/1.e5, rperi*units.l/RSUN);
 
                         /* destroy two progenitors */
                         destroy_obj(k);
@@ -576,13 +634,41 @@ void sscollision_do(long k, long kp, double rperimax, double w[4], double W, dou
 
 
                         /* log collision */
-                        parafprintf(collisionfile, "t=%g single-single idm=%ld(mm=%g) id1=%ld(m1=%g):id2=%ld(m2=%g) (r=%g) typem=%d type1=%d type2=%d b[RSUN]=%g vinf[km/s]=%g rad1=%g rad2=%g rperi=%g coll_mult=%g\n",
+                        parafprintf(collisionfile, "t=%g single-single idm=%ld(mm=%g) id1=%ld(m1=%g):id2=%ld(m2=%g) (r=%g) typem=%d type1=%d type2=%d rad1[RSUN]=%g rad2[RSUN]=%g b[RSUN]=%g vinf[km/s]=%g rperi=%g coll_mult=%g\n",
                                 TotalTime,
                                 star[knew].id, star_m[get_global_idx(knew)] * units.mstar / FB_CONST_MSUN,
                                 star[k].id, mass_k * units.mstar / FB_CONST_MSUN,
                                 star[kp].id, mass_kp * units.mstar / FB_CONST_MSUN,
                                 star_r[get_global_idx(knew)], star[knew].se_k, star[k].se_k, star[kp].se_k,
-                    b*units.l/RSUN,W*units.l/units.t/1.e5, star[k].rad*units.l/RSUN, star[kp].rad*units.l/RSUN, rperi*units.l/RSUN, collisions_multiple_hold);
+				star[k].rad*units.l/RSUN, star[kp].rad*units.l/RSUN,
+                    b*units.l/RSUN,W*units.l/units.t/1.e5, rperi*units.l/RSUN, collisions_multiple_hold);
+
+			/*Elena: Creating a file with additional collision information */
+			double rho0_c = (star[k].se_mc ) / ((4/3)* PI * pow((star[k].se_rc),3));
+			double rho1_c = (star[kp].se_mc ) / ((4/3)* PI * pow((star[kp].se_rc ),3));
+			double rho0_env = (star[k].se_menv ) / ((4/3)* PI * pow((star[k].se_renv ),3));
+			double rho1_env = (star[kp].se_menv ) / ((4/3)* PI *pow((star[kp].se_renv ),3));
+			double rhor_c = (star[knew].se_mc ) / ((4/3)* PI *pow((star[knew].se_rc ),3));
+			double rhor_env = (star[knew].se_menv ) / ((4/3)* PI * pow((star[knew].se_renv),3));
+
+			if(isnan(rho0_c)){rho0_c = -100;}
+			if(isnan(rho1_c)){rho1_c = -100;}
+			if(isnan(rhor_c)){rhor_c = -100;}
+			if(isnan(rho0_env)){rho0_env = -100;}
+			if(isnan(rho1_env)){rho1_env = -100;}
+			if(isnan(rhor_env)){rhor_env = -100;}
+			
+			// Elena: For some stars, COSMIC assigns default renv and menv values of of e-10, which makes my densities exactly 3.1831e-19. I 				will change these vales to output a -100 intead, since it is not physical //
+			
+
+			if(rho0_env >= 1.0e19){rho0_env = -100;}
+			if(rho1_env >= 1.0e19){rho1_env = -100;}
+			if(rhor_env >= 1.0e19){rhor_env = -100;}
+			
+			parafprintf(morecollfile, "%g single-single %ld %ld %g %g %g %g %g %g %g %g %d %d %ld %g %g %g %g %d %g %g\n",
+				    TotalTime, star[k].id, star[kp].id, mass_k * units.mstar / FB_CONST_MSUN, mass_kp * units.mstar / FB_CONST_MSUN,
+				    star[k].rad*units.l/RSUN, star[kp].rad*units.l/RSUN,rho0_c,rho1_c,rho0_env, rho1_env, star[k].se_k, star[kp].se_k,
+				    star[knew].id, star_m[get_global_idx(knew)] * units.mstar / FB_CONST_MSUN, star[knew].rad*units.l/RSUN, rhor_c, rhor_env, star[knew].se_k, W*units.l/units.t/1.e5, rperi*units.l/RSUN);
 
                         /* destroy two progenitors */
                         destroy_obj(k);
@@ -771,13 +857,41 @@ void sscollision_do(long k, long kp, double rperimax, double w[4], double W, dou
 
 
                 /* log collision */
-                parafprintf(collisionfile, "t=%g single-single idm=%ld(mm=%g) id1=%ld(m1=%g):id2=%ld(m2=%g) (r=%g) typem=%d type1=%d type2=%d b[RSUN]=%g vinf[km/s]=%g rad1=%g rad2=%g rperi=%g coll_mult=%g\n",
+                parafprintf(collisionfile, "t=%g single-single idm=%ld(mm=%g) id1=%ld(m1=%g):id2=%ld(m2=%g) (r=%g) typem=%d type1=%d type2=%d rad1[RSUN]=%g rad2[RSUN]=%g b[RSUN]=%g vinf[km/s]=%g rperi=%g coll_mult=%g\n",
                         TotalTime,
                         star[knew].id, star_m[get_global_idx(knew)] * units.mstar / FB_CONST_MSUN,
                         star[k].id, mass_k * units.mstar / FB_CONST_MSUN,
                         star[kp].id, mass_kp * units.mstar / FB_CONST_MSUN,
                         star_r[get_global_idx(knew)], star[knew].se_k, star[k].se_k, star[kp].se_k,
-            b*units.l/RSUN,W*units.l/units.t/1.e5, star[k].rad*units.l/RSUN, star[kp].rad*units.l/RSUN, rperi*units.l/RSUN, collisions_multiple);
+	                star[k].rad*units.l/RSUN, star[kp].rad*units.l/RSUN,
+            b*units.l/RSUN,W*units.l/units.t/1.e5, rperi*units.l/RSUN, collisions_multiple);
+
+		/*Elena: Creating a file with additional collision information */
+			double rho0_c   = (star[k].se_mc)     / ((4/3)* PI * pow((star[k].se_rc),3));
+			double rho1_c   = (star[kp].se_mc)    / ((4/3)* PI * pow((star[kp].se_rc),3));
+			double rho0_env = (star[k].se_menv)   / ((4/3)* PI * pow((star[k].se_renv),3));
+			double rho1_env = (star[kp].se_menv)  / ((4/3)* PI * pow((star[kp].se_renv),3));
+			double rhor_c   = (star[knew].se_mc)  / ((4/3)* PI * pow((star[knew].se_rc),3));
+			double rhor_env = (star[knew].se_menv)/ ((4/3)* PI * pow((star[knew].se_renv),3));
+
+			if(isnan(rho0_c)){rho0_c = -100;}
+			if(isnan(rho1_c)){rho1_c = -100;}
+			if(isnan(rhor_c)){rhor_c = -100;}
+			if(isnan(rho0_env)){rho0_env = -100;}
+			if(isnan(rho1_env)){rho1_env = -100;}
+			if(isnan(rhor_env)){rhor_env = -100;}
+			
+			// Elena: For some stars, COSMIC assigns default renv and menv values of of e-10, which makes my densities exactly 3.1831e-19. I 				will change these vales to output a -100 intead, since it is not physical //
+	
+
+			if(rho0_env >= 1.0e19){rho0_env = -100;}
+			if(rho1_env >= 1.0e19){rho1_env = -100;}
+			if(rhor_env >= 1.0e19){rhor_env = -100;}
+				
+			parafprintf(morecollfile, "%g single-single %ld %ld %g %g %g %g %g %g %g %g %d %d %ld %g %g %g %g %d %g %g\n",
+				    TotalTime, star[k].id, star[kp].id, mass_k * units.mstar / FB_CONST_MSUN, mass_kp * units.mstar / FB_CONST_MSUN,
+				    star[k].rad*units.l/RSUN, star[kp].rad*units.l/RSUN,rho0_c,rho1_c,rho0_env, rho1_env, star[k].se_k, star[kp].se_k,
+				    star[knew].id, star_m[get_global_idx(knew)] * units.mstar / FB_CONST_MSUN, star[knew].rad*units.l/RSUN, rhor_c, 					    rhor_env, star[knew].se_k, W*units.l/units.t/1.e5, rperi*units.l/RSUN);
 
                 /* destroy two progenitors */
                 destroy_obj(k);
@@ -871,13 +985,41 @@ void sscollision_do(long k, long kp, double rperimax, double w[4], double W, dou
                                         - 0.5 * star_m[g_knew] * madhoc * star_phi[g_knew];
 
                                 /* log collision */
-                                parafprintf(collisionfile, "t=%g single-single idm=%ld(mm=%g) id1=%ld(m1=%g):id2=%ld(m2=%g) (r=%g) typem=%d type1=%d type2=%d b[RSUN]=%g vinf[km/s]=%g rad1=%g rad2=%g rperi=%g coll_mult=%g\n",
+                                parafprintf(collisionfile, "t=%g single-single idm=%ld(mm=%g) id1=%ld(m1=%g):id2=%ld(m2=%g) (r=%g) typem=%d type1=%d type2=%d rad1[RSUN]=%g rad2[RSUN]=%g b[RSUN]=%g vinf[km/s]=%g rperi=%g coll_mult=%g\n",
                                         TotalTime,
                                         star[knew].id, star_m[get_global_idx(knew)] * units.mstar / FB_CONST_MSUN,
                                         star[k].id, mass_k * units.mstar / FB_CONST_MSUN,
                                         star[kp].id, mass_kp * units.mstar / FB_CONST_MSUN,
                                         star_r[get_global_idx(knew)], star[knew].se_k, star[k].se_k, star[kp].se_k,
-                            b*units.l/RSUN,W*units.l/units.t/1.e5, star[k].rad*units.l/RSUN, star[kp].rad*units.l/RSUN, rperi*units.l/RSUN, rperi/(star[k].rad+star[kp].rad));
+			                star[k].rad*units.l/RSUN, star[kp].rad*units.l/RSUN,
+                            b*units.l/RSUN,W*units.l/units.t/1.e5, rperi*units.l/RSUN, rperi/(star[k].rad+star[kp].rad));
+
+				/*Elena: Creating a file with additional collision information */
+				
+			double rho0_c   = (star[k].se_mc)      / ((4/3)* PI * pow((star[k].se_rc),3));
+			double rho1_c   = (star[kp].se_mc)     / ((4/3)* PI * pow((star[kp].se_rc),3));
+			double rho0_env = (star[k].se_menv)    / ((4/3)* PI * pow((star[k].se_renv),3));
+			double rho1_env = (star[kp].se_menv)   / ((4/3)* PI * pow((star[kp].se_renv),3));
+			double rhor_c   = (star[knew].se_mc)   / ((4/3)* PI * pow((star[knew].se_rc),3));
+			double rhor_env = (star[knew].se_menv) / ((4/3)* PI * pow((star[knew].se_renv),3));
+	
+			if(isnan(rho0_c)){rho0_c = -100;}
+			if(isnan(rho1_c)){rho1_c = -100;}
+			if(isnan(rhor_c)){rhor_c = -100;}
+			if(isnan(rho0_env)){rho0_env = -100;}
+			if(isnan(rho1_env)){rho1_env = -100;}
+			if(isnan(rhor_env)){rhor_env = -100;}
+			
+			// Elena: For some stars, COSMIC assigns default renv and menv values of of e-10, which makes my densities exactly 3.1831e-19. I will change these vales to output a -100 intead, since it is not physical //
+	
+			if(rho0_env >= 1.0e19){rho0_env = -100;}
+			if(rho1_env >= 1.0e19){rho1_env = -100;}
+			if(rhor_env >= 1.0e19){rhor_env = -100;}
+			
+			parafprintf(morecollfile, "%g single-single %ld %ld %g %g %g %g %g %g %g %g %d %d %ld %g %g %g %g %d %g %g\n",
+				    TotalTime, star[k].id, star[kp].id, mass_k * units.mstar / FB_CONST_MSUN, mass_kp * units.mstar / FB_CONST_MSUN,
+				    star[k].rad*units.l/RSUN, star[kp].rad*units.l/RSUN,rho0_c,rho1_c,rho0_env, rho1_env, star[k].se_k, star[kp].se_k,
+				    star[knew].id, star_m[get_global_idx(knew)] * units.mstar / FB_CONST_MSUN, star[knew].rad*units.l/RSUN, rhor_c, 					    rhor_env, star[knew].se_k, W*units.l/units.t/1.e5, rperi*units.l/RSUN);
 
                                 /* destroy two progenitors */
                                 destroy_obj(k);
@@ -1088,7 +1230,7 @@ void merge_two_stars(star_t *star1, star_t *star2, star_t *merged_star, double *
 		    ktry = 1;
 		    while (tempbinary.bse_mass[0] != 0.0 && tempbinary.bse_mass[1] != 0.0 && ktry < 10) {
 		      dprintf("Attempting to force merger in CE possibly by repeating evolution with a change of sep and lambda.\n");
-		      if(ktry>2){
+		      if(ktry>0){
 			lamb_val = -0.0001/((float)ktry);
 			bse_set_lambdaf(lamb_val); //perhaps should do this in the second attempt? 
 		      }

--- a/src/cmc/cmc_sscollision.c
+++ b/src/cmc/cmc_sscollision.c
@@ -1230,7 +1230,7 @@ void merge_two_stars(star_t *star1, star_t *star2, star_t *merged_star, double *
 		    ktry = 1;
 		    while (tempbinary.bse_mass[0] != 0.0 && tempbinary.bse_mass[1] != 0.0 && ktry < 10) {
 		      dprintf("Attempting to force merger in CE possibly by repeating evolution with a change of sep and lambda.\n");
-		      if(ktry>0){
+		      if(ktry>2){
 			lamb_val = -0.0001/((float)ktry);
 			bse_set_lambdaf(lamb_val); //perhaps should do this in the second attempt? 
 		      }

--- a/src/cmc/cmc_utils.c
+++ b/src/cmc/cmc_utils.c
@@ -1928,6 +1928,7 @@ void set_global_vars1()
     mpi_relaxationfile_len=0;
     mpi_pulsarfile_len=0;
     mpi_morepulsarfile_len=0;
+    mpi_morecollfile_len=0;
     mpi_triplefile_len=0;
 
     mpi_logfile_ofst_total=0;
@@ -1941,6 +1942,7 @@ void set_global_vars1()
     mpi_relaxationfile_ofst_total=0;
     mpi_pulsarfile_ofst_total=0;
     mpi_morepulsarfile_ofst_total=0;
+    mpi_morecollfile_ofst_total=0;
     mpi_triplefile_ofst_total=0;
 }
 


### PR DESCRIPTION
*Changes in semergedisrupt.log file 
> Changed the output of the semergedisrupt.log file to include the radii of the objects involved. To get the radii from within the code, I created the `binint_get_radii` function in the cmc_dynamics.c file.

*Changes in collision.log file
> Changed the output of the collision.log file to include the radii of the objects colliding. 

*Changes in bhmerger.dat
> Changed the output of the bhmerger.dat file to include the ID of the merger product. 

*Created a new output file called morecoll.dat
> If the flag `WRITE_MORECOLL_INFO` is on, a file called morecoll.dat will be created. This file has information about the masses, radii, and densities of colliding objects and the remnant. The information on this file might be useful for users that may want to model the properties of stellar collision products. To create this file, I wrote the following functions within the cmc_dynamics.c file to get the properties of interest: `binint_get_core_mass`, `binint_get_env_mass`, `binint_get_core_radii`, `binint_get_env_radii`, `binint_get_core_mass`.