### PR TITLE
 Correcting window size for mass averages. 

### DIFF
--- a/src/cmc/cmc_dynamics_helper.c
+++ b/src/cmc/cmc_dynamics_helper.c
@@ -3001,7 +3001,7 @@ double calc_average_mass_sqr(long index, long N_LIMIT) {
   si= index;
 
   /* calculate sliding average timesteps */
-  p = MAX((long) (1.0e-4 * ((double) clus.N_STAR) / 2.0), AVEKERNEL);
+  p = AVEKERNEL
   simin = si - p;
   simax = simin + (2 * p - 1);
   if (simin < 1) {

--- a/src/cmc/cmc_dynamics_helper.c
+++ b/src/cmc/cmc_dynamics_helper.c
@@ -3001,7 +3001,7 @@ double calc_average_mass_sqr(long index, long N_LIMIT) {
   si= index;
 
   /* calculate sliding average timesteps */
-  p = AVEKERNEL
+  p = AVEKERNEL;
   simin = si - p;
   simax = simin + (2 * p - 1);
   if (simin < 1) {


### PR DESCRIPTION
* Currently, the local squared mass averages are calculated within a window that is either AVEKERNEL or 1.0e-4 * ((double) clus.N_STAR) / 2.0. For clusters with a large number of stars, this means that mass averages are computed over a window containing thousands of neighbors. This is inconsitent with the fact that other averaged local quantities (like calc_n_local) are always calculated in a fixed window, and it is likely just legacy code that was never changed.