### PR TITLE
COSMIC 4.0 upgrade: submodule bump, kick_info rework, and build fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,15 @@ endforeach()
 
 project(CMC VERSION 1.0.0 LANGUAGES C Fortran)
 
+# CMC's C sources predate C23 and rely on pre-C23 semantics — notably empty
+# parameter lists () meaning "unspecified args" rather than (void). GCC 15
+# defaults to C23 (gnu23), which turns those long-standing idioms into hard
+# errors (e.g. conflicting decls of inv_comm_create); GCC 14 defaulted to gnu17.
+# Pin gnu17 so a compiler default-standard bump doesn't break the build.
+set(CMAKE_C_STANDARD 17)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS ON)
+
 # On macOS, force Xcode's ar/ranlib (BSD-format archives) over any Homebrew
 # binutils GNU ar that may be earlier in PATH. Apple's ld rejects SysV-format
 # archives with "archive member '/' not a mach-o file".

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,20 @@ endforeach()
 
 project(CMC VERSION 1.0.0 LANGUAGES C Fortran)
 
+# On macOS, force Xcode's ar/ranlib (BSD-format archives) over any Homebrew
+# binutils GNU ar that may be earlier in PATH. Apple's ld rejects SysV-format
+# archives with "archive member '/' not a mach-o file".
+if(APPLE)
+    execute_process(COMMAND xcrun -f ar OUTPUT_VARIABLE _xcrun_ar OUTPUT_STRIP_TRAILING_WHITESPACE)
+    execute_process(COMMAND xcrun -f ranlib OUTPUT_VARIABLE _xcrun_ranlib OUTPUT_STRIP_TRAILING_WHITESPACE)
+    if(_xcrun_ar)
+        set(CMAKE_AR "${_xcrun_ar}" CACHE FILEPATH "Archiver" FORCE)
+    endif()
+    if(_xcrun_ranlib)
+        set(CMAKE_RANLIB "${_xcrun_ranlib}" CACHE FILEPATH "Ranlib" FORCE)
+    endif()
+endif()
+
 # The version number.
 set (CMC_VERSION_MAJOR 1)
 set (CMC_VERSION_MINOR 0)

--- a/ci/Params.ini
+++ b/ci/Params.ini
@@ -242,18 +242,28 @@ qcrit_array = [0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0]
 ;;; KICK FLAGS ;;;
 ;;;;;;;;;;;;;;;;;;
 
-; kickflag sets the particular kick prescription to use
-; kickflag=0 uses the standard kick prescription, where kicks are drawn from a bimodal
-; distribution based on whether they go through FeCCSN or ECSN/USSN
-; kickflag=-1 uses the prescription from Giacobbo & Mapelli 2020 (Eq. 1)
-; with their default parameters (<m_ns>=1.2 Msun, <m_ej>=9 Msun)
-; kickflag=-2 uses the prescription from Giacobbo & Mapelli 2020 (Eq. 2),
-; which does not scale the kick by <m_ns>
-; kickflag=-3 uses the prescription from Bray & Eldridge 2016 (Eq. 1)
-; with their default parameters (alpha=70 km/s, beta=120 km/s)
-; Note: sigmadiv, bhflag, bhsigmafrac, aic, and ussn are only used when kickflag=0
-; default = 0
-kickflag = 0
+; kickflag sets the particular natal kick prescription to use.
+; Note that sigmadiv, bhflag, bhsigmafrac, aic, and ussn, which are described below,
+; are only used when abs(kickflag)=1.
+; Positive values use the Pfahl+2002 prescription for handling natal kicks.
+; 1: The standard COSMIC kick prescription,
+; where kicks are drawn from a bimodal distribution with standard FeCCSN getting a kick
+; drawn from a Maxwellian distribution with dispersion parameter sigma and
+; ECSN/USSN are drawn according to sigmadiv.
+; This setting has additional possible options for bhflag, bhsigmafrac, aic and ussn.
+; 2: Natal kicks are drawn according to sigma and scaled by the ejecta mass and remnant mass
+; following Eq. 1 of Giacobbo & Mapelli 2020 with their default parameters
+; (\(m_{\rm NS = 1.2 {\rm M_\odot}\), \(m_{\rm ej = 9 {\rm M_\odot}\))
+; 3: Natal kicks are drawn according to sigma and scaled by just the ejecta mass following Eq. 2 of
+; Giacobbo & Mapelli 2020, which does not scale the kick by (\(m_{\rm NS\)
+; 4: Natal kicks are drawn according to Eq. 1 of Bray & Eldridge 2016,
+; with their default parameters (\(\alpha=70 \, {\rm km/s}, \beta = 120 \, {\rm km/s)}
+; 5: Follows the same prescription as 1, but uses the kick prescription described in Disberg & Mandel 2025 for CCSN.
+; negative values: Same as above settings but using the old Kiel & Hurley 2009 prescription
+; for changing the orbital configuration of the binary,
+; available for reproducibility purposes but not recommended for new work
+; default = 1
+kickflag = 1
 
 ; sigma sets is the dispersion in the Maxwellian for the SN kick velocity in km/s
 ; default = 265.0

--- a/docs/sphinx/source/example_output/KingProfile.ini
+++ b/docs/sphinx/source/example_output/KingProfile.ini
@@ -435,18 +435,28 @@ qcrit_array = [0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0]
 ;;; KICK FLAGS ;;;
 ;;;;;;;;;;;;;;;;;;
 
-; kickflag sets the particular kick prescription to use
-; kickflag=0 uses the standard kick prescription, where kicks are drawn from a bimodal
-; distribution based on whether they go through FeCCSN or ECSN/USSN
-; kickflag=-1 uses the prescription from Giacobbo & Mapelli 2020 (Eq. 1)
-; with their default parameters (<m_ns>=1.2 Msun, <m_ej>=9 Msun)
-; kickflag=-2 uses the prescription from Giacobbo & Mapelli 2020 (Eq. 2),
-; which does not scale the kick by <m_ns>
-; kickflag=-3 uses the prescription from Bray & Eldridge 2016 (Eq. 1)
-; with their default parameters (alpha=70 km/s, beta=120 km/s)
-; Note: sigmadiv, bhflag, bhsigmafrac, aic, and ussn are only used when kickflag=0
-; default = 0
-kickflag = 0
+; kickflag sets the particular natal kick prescription to use.
+; Note that sigmadiv, bhflag, bhsigmafrac, aic, and ussn, which are described below,
+; are only used when abs(kickflag)=1.
+; Positive values use the Pfahl+2002 prescription for handling natal kicks.
+; 1: The standard COSMIC kick prescription,
+; where kicks are drawn from a bimodal distribution with standard FeCCSN getting a kick
+; drawn from a Maxwellian distribution with dispersion parameter sigma and
+; ECSN/USSN are drawn according to sigmadiv.
+; This setting has additional possible options for bhflag, bhsigmafrac, aic and ussn.
+; 2: Natal kicks are drawn according to sigma and scaled by the ejecta mass and remnant mass
+; following Eq. 1 of Giacobbo & Mapelli 2020 with their default parameters
+; (\(m_{\rm NS = 1.2 {\rm M_\odot}\), \(m_{\rm ej = 9 {\rm M_\odot}\))
+; 3: Natal kicks are drawn according to sigma and scaled by just the ejecta mass following Eq. 2 of
+; Giacobbo & Mapelli 2020, which does not scale the kick by (\(m_{\rm NS\)
+; 4: Natal kicks are drawn according to Eq. 1 of Bray & Eldridge 2016,
+; with their default parameters (\(\alpha=70 \, {\rm km/s}, \beta = 120 \, {\rm km/s)}
+; 5: Follows the same prescription as 1, but uses the kick prescription described in Disberg & Mandel 2025 for CCSN.
+; negative values: Same as above settings but using the old Kiel & Hurley 2009 prescription
+; for changing the orbital configuration of the binary,
+; available for reproducibility purposes but not recommended for new work
+; default = 1
+kickflag = 1
 
 ; sigma sets is the dispersion in the Maxwellian for the SN kick velocity in km/s
 ; default = 265.0

--- a/examples/KingProfile.ini
+++ b/examples/KingProfile.ini
@@ -317,6 +317,36 @@ SAMPLESIZE = 1024
 ; number of central stars used to calculate certain averages
 NUM_CENTRAL_STARS = 300
 
+[sse]
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; Single Star Evolution;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+; STELLAR_ENGINE selects the stellar evolution tracks used by COSMIC.
+; STELLAR_ENGINE = sse:     SSE fitting formulae (Hurley et al. 2000, 2002)
+; STELLAR_ENGINE = metisse: METISSE interpolated tracks (Agrawal et al. 2020, 2023);
+;                           requires PATH_TO_TRACKS and PATH_TO_HE_TRACKS.
+; default = sse
+STELLAR_ENGINE = sse
+
+; Directory of main-sequence stellar evolution tracks for METISSE to interpolate.
+; Required if STELLAR_ENGINE = metisse. Use None when STELLAR_ENGINE = sse.
+PATH_TO_TRACKS = None
+
+; Directory of helium-star evolution tracks for METISSE to interpolate.
+; Required if STELLAR_ENGINE = metisse. Use None when STELLAR_ENGINE = sse.
+PATH_TO_HE_TRACKS = None
+
+; Maximum allowed relative difference between the requested metallicity and the
+; metallicity of the available METISSE tracks. Increase slightly if METISSE
+; errors out due to metallicity mismatch.
+; default = 1e-2
+Z_MATCH_LIMIT = 1e-2
+
+; Enable verbose METISSE diagnostic output (0 = off, 1 = on).
+; default = 0
+METISSE_VERBOSE = 0
+
 [bse]
 
 ; turn stellar evolution on or off in CMC

--- a/examples/KingProfile.ini
+++ b/examples/KingProfile.ini
@@ -489,19 +489,28 @@ qcrit_array = [0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0]
 ;;;;;;;;;;;;;;;;;;
 ;;; KICK FLAGS ;;;
 ;;;;;;;;;;;;;;;;;;
-
-; kickflag sets the particular kick prescription to use
-; kickflag=0 uses the standard kick prescription, where kicks are drawn from a bimodal
-; distribution based on whether they go through FeCCSN or ECSN/USSN
-; kickflag=-1 uses the prescription from Giacobbo & Mapelli 2020 (Eq. 1)
-; with their default parameters (<m_ns>=1.2 Msun, <m_ej>=9 Msun)
-; kickflag=-2 uses the prescription from Giacobbo & Mapelli 2020 (Eq. 2),
-; which does not scale the kick by <m_ns>
-; kickflag=-3 uses the prescription from Bray & Eldridge 2016 (Eq. 1)
-; with their default parameters (alpha=70 km/s, beta=120 km/s)
-; Note: sigmadiv, bhflag, bhsigmafrac, aic, and ussn are only used when kickflag=0
-; default = 0
-kickflag = 0
+; kickflag sets the particular natal kick prescription to use. 
+; Note that sigmadiv, bhflag, bhsigmafrac, aic, and ussn, which are described below, 
+; are only used when abs(kickflag)=1. 
+; Positive values use the Pfahl+2002 prescription for handling natal kicks.
+; 1: The standard COSMIC kick prescription, 
+; where kicks are drawn from a bimodal distribution with standard FeCCSN getting a kick 
+; drawn from a Maxwellian distribution with dispersion parameter sigma and 
+; ECSN/USSN are drawn according to sigmadiv. 
+; This setting has additional possible options for bhflag, bhsigmafrac, aic and ussn.
+; 2: Natal kicks are drawn according to sigma and scaled by the ejecta mass and remnant mass 
+; following Eq. 1 of Giacobbo & Mapelli 2020 with their default parameters 
+; (\(m_{\rm NS = 1.2 {\rm M_\odot}\), \(m_{\rm ej = 9 {\rm M_\odot}\))
+; 3: Natal kicks are drawn according to sigma and scaled by just the ejecta mass following Eq. 2 of 
+; Giacobbo & Mapelli 2020, which does not scale the kick by (\(m_{\rm NS\)
+; 4: Natal kicks are drawn according to Eq. 1 of Bray & Eldridge 2016, 
+; with their default parameters (\(\alpha=70 \, {\rm km/s}, \beta = 120 \, {\rm km/s)}
+; 5: Follows the same prescription as 1, but uses the kick prescription described in Disberg & Mandel 2025 for CCSN.
+; negative values: Same as above settings but using the old Kiel & Hurley 2009 prescription 
+; for changing the orbital configuration of the binary, 
+; available for reproducibility purposes but not recommended for new work
+; default = 1
+kickflag = 1
 
 ; sigma sets is the dispersion in the Maxwellian for the SN kick velocity in km/s
 ; default = 265.0

--- a/include/bse_wrap/bse_wrap.h
+++ b/include/bse_wrap/bse_wrap.h
@@ -139,8 +139,8 @@ void evolv2_(int *kstar, double *mass, double *tb, double *ecc, double *z,
 	     double *tphysf, double *dtp, double *mass0, double *rad, double *lum,
              double *massc, double *radc, double *menv, double *renv,
 	     double *ospin, double *B_0, double *bacc, double *tacc, double *epoch,
-	     double *tms, double *bhspin, double *tphys, double *zpars, double *vs, double *kick_info,
-	     int *bpp_index_out, int *bcm_index_out, double *kick_info_out);
+	     double *tms, double *bhspin, double *tphys, double *zpars, double *kick_info,
+	     int *bpp_index_out, int *bcm_index_out);
 void instar_(void);
 float ran3_(int *idum);
 void star_(int *kw, double *mass, double *mt, double *tm, double *tn, double *tscls,
@@ -149,10 +149,10 @@ void hrdiag_(double *mass, double *aj, double *mt, double *tm, double *tn, doubl
 	     double *lums, double *GB, double *zpars, double *r, double *lum, int *kw, 
 	     double *mc, double *rc, double *menv, double *renv, double *k2,  double *bhspin, int *kidx);
 void kick_(int *kw, double *m1, double *m1n, double *m2, double *ecc, double *sep, 
-	   double *jorb, double *vk, int *snstar, double *r2, double *fallback, double *sigmahold, double *kick_info, int *disrupt, double *vs);
+	   double *jorb, double *vk, int *snstar, double *r2, double *fallback, double *sigmahold, double *kick_info, int *disrupt);
 void mix_(double *mass, double *mt, double *aj, int *kw, double *zpars, double *bhspin, double *dtm);
 // note: these function names only work if in lowercase here, even though FORTRAN versions in uppercase.
-void comenv_(double *M01, double *M1, double *MC1, double *AJ1, double *JSPIN1, int *KW1, double *M02, double *M2, double *MC2, double *AJ2, double *JSPIN2, int *KW2, double *ZPARS, double *ECC, double *SEP, double *JORB, int *COEL, int *star1, int *star2, double *vk, double *kick_info, int *formation1, int *formation2, double *sigmahold, double *bhspin1, double *bhspin2, int *binstate, int *mergertype, int *jp, double *tphys,int *swtichedCE, double *rad, double *tms, double *evolve_type, int *disrupt, double * lumin, double * B_0, double * bacc, double * tacc, double * epoch, double * menv_bpp, double * renv_bpp, double *bkick, double *deltam_1, double *deltam_2, double *dtm);
+void comenv_(double *M01, double *M1, double *MC1, double *AJ1, double *JSPIN1, int *KW1, double *M02, double *M2, double *MC2, double *AJ2, double *JSPIN2, int *KW2, double *ZPARS, double *ECC, double *SEP, double *JORB, int *COEL, int *star1, int *star2, double *vk, double *kick_info, int *formation1, int *formation2, double *sigmahold, double *bhspin1, double *bhspin2, int *binstate, int *mergertype, int *jp, double *tphys,int *swtichedCE, double *rad, double *tms, double *evolve_type, int *disrupt, double * lumin, double * B_0, double * bacc, double * tacc, double * epoch, double * menv_bpp, double * renv_bpp, double *deltam_1, double *deltam_2, double *dtm);
 
 
 /* wrapped BSE functions */
@@ -161,16 +161,16 @@ void bse_evolv2(int *kstar, double *mass0, double *mass, double *rad, double *lu
 		double *massc, double *radc, double *menv, double *renv, double *ospin,
                 double *B_0, double *bacc, double *tacc,
 		double *epoch, double *tms, double *tphys, double *tphysf, double *dtp,
-		double *z, double *zpars, double *tb, double *ecc, double *vs, double *bhspin);
+		double *z, double *zpars, double *tb, double *ecc, double *kick_info, double *bhspin);
 void bse_evolve_single(int *kw, double *mass, double *mt, double *r, double *lum,
                 double *mc, double *rc, double *menv, double *renv, double *ospin,
                 double *epoch, double *tms, double *tphys, double *tphysf,
-                double *dtp, double *z, double *zpars, double *vs, double *bhspin);
+                double *dtp, double *z, double *zpars, double *kick_info, double *bhspin);
 void bse_evolv2_safely(int *kstar, double *mass0, double *mass, double *rad, double *lum, 
 		       double *massc, double *radc, double *menv, double *renv, double *ospin,
                        double *B_0, double *bacc, double *tacc,
 		       double *epoch, double *tms, double *tphys, double *tphysf, double *dtp,
-		       double *z, double *zpars, double *tb, double *ecc, double *vs, double *bhspin);
+		       double *z, double *zpars, double *tb, double *ecc, double *kick_info, double *bhspin);
 void bse_instar(void);
 void bse_star(int *kw, double *mass, double *mt, double *tm, double *tn, double *tscls, 
 	      double *lums, double *GB, double *zpars);
@@ -178,10 +178,10 @@ void bse_hrdiag(double *mass, double *aj, double *mt, double *tm, double *tn, do
 		double *lums, double *GB, double *zpars, double *r, double *lum, int *kw, 
 		double *mc, double *rc, double *menv, double *renv, double *k2, double *bhspin);
 void bse_kick(int *kw, double *m1, double *m1n, double *m2, double *ecc, double *sep, 
-	      double *jorb, double *vk, int *snstar, double *r2, double *fallback, double *vs);
+	      double *jorb, double *vk, int *snstar, double *r2, double *fallback, double *kick_info);
 void bse_mix(double *mass, double *mt, double *aj, int *kw, double *zpars, double *bhspin);
 void bse_comenv(bse_binary *binary, double *zpars,
-                double *vs, int *fb);
+                double *kick_info, int *fb);
 
 /* structs to access BSE common blocks.
  * Field order/types MUST match the COMMON declarations in COSMIC's

--- a/include/bse_wrap/bse_wrap.h
+++ b/include/bse_wrap/bse_wrap.h
@@ -190,6 +190,7 @@ void bse_comenv(bse_binary *binary, double *zpars,
 extern struct { int idum1; } rand1_;
 extern struct { int idum2, iy, ir[32]; } rand2_;
 extern struct { long long int state[4]; int first; } taus113state_;
+extern struct { long long int umax; } integers_;
 extern struct { int ktype[15][15]; } types_;
 extern struct {
     int tflag, ifflag, remnantflag, wdflag, bhflag, windflag,
@@ -230,6 +231,7 @@ extern struct { double merger; long int id1_pass, id2_pass; long int using_cmc; 
 
 /* setters */
 void bse_set_idum(int idum); /* RNG seed (for NS birth kicks) */
+void bse_init_umax(void);    /* Force-set Tausworth umax mask (workaround for static-link stripping of int64.o BLOCK DATA on macOS) */
 
 void bse_set_neta(double neta); /* Reimers mass-loss coefficent (neta*4x10^-13; 0.5 normally) */
 void bse_set_bwind(double bwind); /* binary enhanced mass loss parameter (inactive for single) */

--- a/include/bse_wrap/bse_wrap.h
+++ b/include/bse_wrap/bse_wrap.h
@@ -23,10 +23,10 @@
 #include <math.h>
 #include "../common/taus113-v2.h"
 
-#define BCM_NUM_COLUMNS 49 
-#define BPP_NUM_COLUMNS 49 
-#define BCM_NUM_ROWS 50000 
-#define BPP_NUM_ROWS 1000 
+#define BCM_NUM_COLUMNS 52
+#define BPP_NUM_COLUMNS 52
+#define BCM_NUM_ROWS 50000
+#define BPP_NUM_ROWS 1000
 
 /**
 * @brief A structure used to pass binary information along to bse_wrap.c
@@ -133,23 +133,26 @@ typedef struct{
 /* prototypes for fortran BSE functions */
 void zcnsts_(double *z, double *zpars);
 void bse_set_bcm_bpp_cols(void);
-void evolv2_(int *kstar, double *mass, double *tb, double *ecc, double *z, 
+int bse_get_bcm_index(void); /* Last bcm-row index written by evolv2 (Fortran 1-indexed). */
+int bse_get_bpp_index(void); /* Last bpp-row index written by evolv2 (Fortran 1-indexed). */
+void evolv2_(int *kstar, double *mass, double *tb, double *ecc, double *z,
 	     double *tphysf, double *dtp, double *mass0, double *rad, double *lum,
              double *massc, double *radc, double *menv, double *renv,
 	     double *ospin, double *B_0, double *bacc, double *tacc, double *epoch,
-	     double *tms, double *bhspin, double *tphys, double *zpars, double *vs, double *kick_info);
+	     double *tms, double *bhspin, double *tphys, double *zpars, double *vs, double *kick_info,
+	     int *bpp_index_out, int *bcm_index_out, double *kick_info_out);
 void instar_(void);
 float ran3_(int *idum);
-void star_(int *kw, double *mass, double *mt, double *tm, double *tn, double *tscls, 
-	   double *lums, double *GB, double *zpars);
+void star_(int *kw, double *mass, double *mt, double *tm, double *tn, double *tscls,
+	   double *lums, double *GB, double *zpars, double *dtm, int *id);
 void hrdiag_(double *mass, double *aj, double *mt, double *tm, double *tn, double *tscls, 
 	     double *lums, double *GB, double *zpars, double *r, double *lum, int *kw, 
 	     double *mc, double *rc, double *menv, double *renv, double *k2,  double *bhspin, int *kidx);
 void kick_(int *kw, double *m1, double *m1n, double *m2, double *ecc, double *sep, 
 	   double *jorb, double *vk, int *snstar, double *r2, double *fallback, double *sigmahold, double *kick_info, int *disrupt, double *vs);
-void mix_(double *mass, double *mt, double *aj, int *kw, double *zpars, double *bhspin);
+void mix_(double *mass, double *mt, double *aj, int *kw, double *zpars, double *bhspin, double *dtm);
 // note: these function names only work if in lowercase here, even though FORTRAN versions in uppercase.
-void comenv_(double *M01, double *M1, double *MC1, double *AJ1, double *JSPIN1, int *KW1, double *M02, double *M2, double *MC2, double *AJ2, double *JSPIN2, int *KW2, double *ZPARS, double *ECC, double *SEP, double *JORB, int *COEL, int *star1, int *star2, double *vk, double *kick_info, int *formation1, int *formation2, double *sigmahold, double *bhspin1, double *bhspin2, int *binstate, int *mergertype, int *jp, double *tphys,int *swtichedCE, double *rad, double *tms, double *evolve_type, int *disrupt, double * lumin, double * B_0, double * bacc, double * tacc, double * epoch, double * menv_bpp, double * renv_bpp, double *bkick);
+void comenv_(double *M01, double *M1, double *MC1, double *AJ1, double *JSPIN1, int *KW1, double *M02, double *M2, double *MC2, double *AJ2, double *JSPIN2, int *KW2, double *ZPARS, double *ECC, double *SEP, double *JORB, int *COEL, int *star1, int *star2, double *vk, double *kick_info, int *formation1, int *formation2, double *sigmahold, double *bhspin1, double *bhspin2, int *binstate, int *mergertype, int *jp, double *tphys,int *swtichedCE, double *rad, double *tms, double *evolve_type, int *disrupt, double * lumin, double * B_0, double * bacc, double * tacc, double * epoch, double * menv_bpp, double * renv_bpp, double *bkick, double *deltam_1, double *deltam_2, double *dtm);
 
 
 /* wrapped BSE functions */
@@ -180,29 +183,49 @@ void bse_mix(double *mass, double *mt, double *aj, int *kw, double *zpars, doubl
 void bse_comenv(bse_binary *binary, double *zpars,
                 double *vs, int *fb);
 
-/* structs to access BSE common blocks */
-/* note the index swap between fortran and C: i,j->j,i */
+/* structs to access BSE common blocks.
+ * Field order/types MUST match the COMMON declarations in COSMIC's
+ * src/cosmic/src/const_bse.h. Mismatches cause memory corruption
+ * across COMMON-block boundaries. */
 extern struct { int idum1; } rand1_;
 extern struct { int idum2, iy, ir[32]; } rand2_;
-extern struct { long long int state[4]; int first;} taus113state_;
+extern struct { long long int state[4]; int first; } taus113state_;
 extern struct { int ktype[15][15]; } types_;
-extern struct { int  tflag, ifflag, remnantflag, wdflag, bhflag, windflag,  qcflag, eddlimflag, bhspinflag, aic, rejuvflag,  htpmb, st_cr, st_tide, bdecayfac, grflag, bhms_coll_flag, wd_mass_lim, rtmsflag; } flags_;
-extern struct { int ceflag,cekickflag,cemergeflag,cehestarflag,ussn; } ceflags_;
+extern struct {
+    int tflag, ifflag, remnantflag, wdflag, bhflag, windflag,
+        qcflag, eddlimflag, bhspinflag, aic, rejuvflag,
+        htpmb, st_cr, st_tide, bdecayfac, grflag,
+        bhms_coll_flag, wd_mass_lim, rtmsflag, maltsev_mode;
+} flags_;
+extern struct { double don_lim, acc_lim[2], Mbh_initial, smt_periastron_check; } mtvars_;
+extern struct { int ceflag, cekickflag, cemergeflag, cehestarflag, ussn; } ceflags_;
 extern struct { int pisn_track[2]; } trackers_;
 extern struct { double zsun; } metvars_;
-extern struct { double don_lim, acc_lim; } mtvars_; 
-
-extern struct { double neta, bwind, hewind, beta, xi, acc2, epsnov, eddfac, gamma; } windvars_;
-extern struct { double qcrit_array[16], alpha1, lambdaf; } cevars_;
+extern struct {
+    double neta, bwind, hewind, beta, xi, acc2, epsnov, eddfac, gamma;
+    int LBV_flag;
+} windvars_;
+extern struct { double qcrit_array[16], alpha1[2], lambdaf; } cevars_;
 extern struct { double bconst, ck; } magvars_;
 extern struct { double rejuv_fac; } mixvars_;
-extern struct { double natal_kick_array[5][2], sigma, sigmadiv, bhsigmafrac, polar_kick_angle, pisn, ecsn, ecsn_mlow, bhspinmag, mxns, rembar_massloss; int kickflag;} snvars_;
+extern struct {
+    double natal_kick_array[5][2];
+    double sigma, sigmadiv, bhsigmafrac;
+    double polar_kick_angle;
+    double pisn, ecsn, ecsn_mlow;
+    double bhspinmag, mxns, rembar_massloss;
+    double mc_he[2], mc_co[2];
+    double mm_mu_ns, mm_mu_bh, maltsev_fallback, maltsev_pf_prob;
+    int kickflag, fryer_mass_limit;
+    double ppi_co_shift, ppi_extra_ml;
+    double fryer_fmix, fryer_mcrit_nsbh;
+} snvars_;
 extern struct { double fprimc_array[16]; } tidalvars_;
 extern struct { double pts1, pts2, pts3; } points_;
 extern struct { double dmmax, drmax; } tstepc_;
-extern struct { double scm[14][50000], spp[3][20]; } single_;
+extern struct { double scm[16][50000], spp[20][25]; } single_;
 extern struct { double bcm[BCM_NUM_COLUMNS][BCM_NUM_ROWS], bpp[BPP_NUM_COLUMNS][BPP_NUM_ROWS]; } binary_;
-extern struct { int n_col_bpp,col_inds_bpp[BCM_NUM_COLUMNS], n_col_bcm,col_inds_bcm[BCM_NUM_COLUMNS]; } col_;
+extern struct { int n_col_bpp, col_inds_bpp[BCM_NUM_COLUMNS], n_col_bcm, col_inds_bcm[BCM_NUM_COLUMNS]; } col_;
 extern struct { double merger; long int id1_pass, id2_pass; long int using_cmc; } cmcpass_;
 
 /* setters */

--- a/include/bse_wrap/bse_wrap.h
+++ b/include/bse_wrap/bse_wrap.h
@@ -148,8 +148,9 @@ void star_(int *kw, double *mass, double *mt, double *tm, double *tn, double *ts
 void hrdiag_(double *mass, double *aj, double *mt, double *tm, double *tn, double *tscls, 
 	     double *lums, double *GB, double *zpars, double *r, double *lum, int *kw, 
 	     double *mc, double *rc, double *menv, double *renv, double *k2,  double *bhspin, int *kidx);
-void kick_(int *kw, double *m1, double *m1n, double *m2, double *ecc, double *sep, 
-	   double *jorb, double *vk, int *snstar, double *r2, double *fallback, double *sigmahold, double kick_info[19][2], int *disrupt);
+void kick_(int *kw, double *m1, double *m1c, double *m1n, double *m2, double *ecc, double *sep,
+	   double *jorb, double *vk, int *snstar, double *r2, double *fallback, double *sigmahold,
+	   double kick_info[19][2], int *disrupt, double *tphys);
 void mix_(double *mass, double *mt, double *aj, int *kw, double *zpars, double *bhspin, double *dtm);
 // note: these function names only work if in lowercase here, even though FORTRAN versions in uppercase.
 void comenv_(double *M01, double *M1, double *MC1, double *AJ1, double *JSPIN1, int *KW1, double *M02, double *M2, double *MC2, double *AJ2, double *JSPIN2, int *KW2, double *ZPARS, double *ECC, double *SEP, double *JORB, int *COEL, int *star1, int *star2, double *vk, double kick_info[19][2], int *formation1, int *formation2, double *sigmahold, double *bhspin1, double *bhspin2, int *binstate, int *mergertype, int *jp, double *tphys,int *swtichedCE, double *rad, double *tms, double *evolve_type, int *disrupt, double * lumin, double * B_0, double * bacc, double * tacc, double * epoch, double * menv_bpp, double * renv_bpp, double *deltam_1, double *deltam_2, double *dtm);
@@ -226,7 +227,8 @@ extern struct { double pts1, pts2, pts3; } points_;
 extern struct { double dmmax, drmax; } tstepc_;
 extern struct { double scm[16][50000], spp[20][25]; } single_;
 extern struct { double bcm[BCM_NUM_COLUMNS][BCM_NUM_ROWS], bpp[BPP_NUM_COLUMNS][BPP_NUM_ROWS]; } binary_;
-extern struct { int n_col_bpp, col_inds_bpp[BCM_NUM_COLUMNS], n_col_bcm, col_inds_bcm[BCM_NUM_COLUMNS]; } col_;
+extern struct { int n_col_bpp, col_inds_bpp[BCM_NUM_COLUMNS], n_col_bcm, col_inds_bcm[BCM_NUM_COLUMNS], bpp_ind; } col_;
+extern struct { int bcm_err; } er_flags_;
 extern struct { double merger; long int id1_pass, id2_pass; long int using_cmc; } cmcpass_;
 
 /* COSMIC 4.0 stellar-evolution engine COMMON blocks.

--- a/include/bse_wrap/bse_wrap.h
+++ b/include/bse_wrap/bse_wrap.h
@@ -229,9 +229,26 @@ extern struct { double bcm[BCM_NUM_COLUMNS][BCM_NUM_ROWS], bpp[BPP_NUM_COLUMNS][
 extern struct { int n_col_bpp, col_inds_bpp[BCM_NUM_COLUMNS], n_col_bcm, col_inds_bcm[BCM_NUM_COLUMNS]; } col_;
 extern struct { double merger; long int id1_pass, id2_pass; long int using_cmc; } cmcpass_;
 
+/* COSMIC 4.0 stellar-evolution engine COMMON blocks.
+ * SE_FLAGS selects SSE vs. METISSE via the Fortran dispatchers in deltat.f,
+ * mlwind.f, hrdiag.f, etc. Both flags default to 0 in COMMON; if neither is
+ * set to 1, the dispatchers no-op and stellar evolution silently breaks.
+ * METISSEVARS holds METISSE-only inputs; LOGICAL maps to 4-byte int with
+ * default gfortran ABI (struct end pads to 528 bytes). */
+extern struct { int using_metisse, using_sse; } se_flags_;
+extern struct {
+	char path_to_tracks[256];
+	char path_to_he_tracks[256];
+	double z_match_limit;
+	int metisse_verbose;
+} metissevars_;
+
 /* setters */
 void bse_set_idum(int idum); /* RNG seed (for NS birth kicks) */
 void bse_init_umax(void);    /* Force-set Tausworth umax mask (workaround for static-link stripping of int64.o BLOCK DATA on macOS) */
+void bse_set_stellar_engine(int stellar_engine); /* 0 = SSE, 1 = METISSE */
+void bse_set_metisse_inputs(char *path_to_tracks, char *path_to_he_tracks,
+                            double z_match_limit, int metisse_verbose);
 
 void bse_set_neta(double neta); /* Reimers mass-loss coefficent (neta*4x10^-13; 0.5 normally) */
 void bse_set_bwind(double bwind); /* binary enhanced mass loss parameter (inactive for single) */

--- a/include/bse_wrap/bse_wrap.h
+++ b/include/bse_wrap/bse_wrap.h
@@ -139,7 +139,7 @@ void evolv2_(int *kstar, double *mass, double *tb, double *ecc, double *z,
 	     double *tphysf, double *dtp, double *mass0, double *rad, double *lum,
              double *massc, double *radc, double *menv, double *renv,
 	     double *ospin, double *B_0, double *bacc, double *tacc, double *epoch,
-	     double *tms, double *bhspin, double *tphys, double *zpars, double *kick_info,
+	     double *tms, double *bhspin, double *tphys, double *zpars, double kick_info[19][2],
 	     int *bpp_index_out, int *bcm_index_out);
 void instar_(void);
 float ran3_(int *idum);
@@ -149,10 +149,10 @@ void hrdiag_(double *mass, double *aj, double *mt, double *tm, double *tn, doubl
 	     double *lums, double *GB, double *zpars, double *r, double *lum, int *kw, 
 	     double *mc, double *rc, double *menv, double *renv, double *k2,  double *bhspin, int *kidx);
 void kick_(int *kw, double *m1, double *m1n, double *m2, double *ecc, double *sep, 
-	   double *jorb, double *vk, int *snstar, double *r2, double *fallback, double *sigmahold, double *kick_info, int *disrupt);
+	   double *jorb, double *vk, int *snstar, double *r2, double *fallback, double *sigmahold, double kick_info[19][2], int *disrupt);
 void mix_(double *mass, double *mt, double *aj, int *kw, double *zpars, double *bhspin, double *dtm);
 // note: these function names only work if in lowercase here, even though FORTRAN versions in uppercase.
-void comenv_(double *M01, double *M1, double *MC1, double *AJ1, double *JSPIN1, int *KW1, double *M02, double *M2, double *MC2, double *AJ2, double *JSPIN2, int *KW2, double *ZPARS, double *ECC, double *SEP, double *JORB, int *COEL, int *star1, int *star2, double *vk, double *kick_info, int *formation1, int *formation2, double *sigmahold, double *bhspin1, double *bhspin2, int *binstate, int *mergertype, int *jp, double *tphys,int *swtichedCE, double *rad, double *tms, double *evolve_type, int *disrupt, double * lumin, double * B_0, double * bacc, double * tacc, double * epoch, double * menv_bpp, double * renv_bpp, double *deltam_1, double *deltam_2, double *dtm);
+void comenv_(double *M01, double *M1, double *MC1, double *AJ1, double *JSPIN1, int *KW1, double *M02, double *M2, double *MC2, double *AJ2, double *JSPIN2, int *KW2, double *ZPARS, double *ECC, double *SEP, double *JORB, int *COEL, int *star1, int *star2, double *vk, double kick_info[19][2], int *formation1, int *formation2, double *sigmahold, double *bhspin1, double *bhspin2, int *binstate, int *mergertype, int *jp, double *tphys,int *swtichedCE, double *rad, double *tms, double *evolve_type, int *disrupt, double * lumin, double * B_0, double * bacc, double * tacc, double * epoch, double * menv_bpp, double * renv_bpp, double *deltam_1, double *deltam_2, double *dtm);
 
 
 /* wrapped BSE functions */
@@ -161,16 +161,16 @@ void bse_evolv2(int *kstar, double *mass0, double *mass, double *rad, double *lu
 		double *massc, double *radc, double *menv, double *renv, double *ospin,
                 double *B_0, double *bacc, double *tacc,
 		double *epoch, double *tms, double *tphys, double *tphysf, double *dtp,
-		double *z, double *zpars, double *tb, double *ecc, double *kick_info, double *bhspin);
+		double *z, double *zpars, double *tb, double *ecc, double kick_info[19][2], double *bhspin);
 void bse_evolve_single(int *kw, double *mass, double *mt, double *r, double *lum,
                 double *mc, double *rc, double *menv, double *renv, double *ospin,
                 double *epoch, double *tms, double *tphys, double *tphysf,
-                double *dtp, double *z, double *zpars, double *kick_info, double *bhspin);
+                double *dtp, double *z, double *zpars, double kick_info[19][2], double *bhspin);
 void bse_evolv2_safely(int *kstar, double *mass0, double *mass, double *rad, double *lum, 
 		       double *massc, double *radc, double *menv, double *renv, double *ospin,
                        double *B_0, double *bacc, double *tacc,
 		       double *epoch, double *tms, double *tphys, double *tphysf, double *dtp,
-		       double *z, double *zpars, double *tb, double *ecc, double *kick_info, double *bhspin);
+		       double *z, double *zpars, double *tb, double *ecc, double kick_info[19][2], double *bhspin);
 void bse_instar(void);
 void bse_star(int *kw, double *mass, double *mt, double *tm, double *tn, double *tscls, 
 	      double *lums, double *GB, double *zpars);
@@ -178,10 +178,10 @@ void bse_hrdiag(double *mass, double *aj, double *mt, double *tm, double *tn, do
 		double *lums, double *GB, double *zpars, double *r, double *lum, int *kw, 
 		double *mc, double *rc, double *menv, double *renv, double *k2, double *bhspin);
 void bse_kick(int *kw, double *m1, double *m1n, double *m2, double *ecc, double *sep, 
-	      double *jorb, double *vk, int *snstar, double *r2, double *fallback, double *kick_info);
+	      double *jorb, double *vk, int *snstar, double *r2, double *fallback, double kick_info[19][2]);
 void bse_mix(double *mass, double *mt, double *aj, int *kw, double *zpars, double *bhspin);
 void bse_comenv(bse_binary *binary, double *zpars,
-                double *kick_info, int *fb);
+                double kick_info[19][2], int *fb);
 
 /* structs to access BSE common blocks.
  * Field order/types MUST match the COMMON declarations in COSMIC's

--- a/include/cmc/cmc.h
+++ b/include/cmc/cmc.h
@@ -1923,7 +1923,7 @@ void stellar_evolution_init(void);
 void restart_stellar_evolution(void);
 void do_stellar_evolution(gsl_rng *rng);
 void write_stellar_data(void);
-void handle_bse_outcome(long k, long kb, double kick_info[19][2], double tphysf, int kprev0, int kprev1, double *VKO);
+void handle_bse_outcome(long k, long kb, double kick_info[19][2], double tphysf, int kprev0, int kprev1, double VKO[2]);
 void cp_binmemb_to_star(long k, int kbi, long knew);
 void cp_SEvars_to_newstar(long oldk, int kbi, long knew);
 void cp_m_to_newstar(long oldk, int kbi, long knew);

--- a/include/cmc/cmc.h
+++ b/include/cmc/cmc.h
@@ -1923,7 +1923,7 @@ void stellar_evolution_init(void);
 void restart_stellar_evolution(void);
 void do_stellar_evolution(gsl_rng *rng);
 void write_stellar_data(void);
-void handle_bse_outcome(long k, long kb, double *vs, double tphysf, int kprev0, int kprev1, double *VKO);
+void handle_bse_outcome(long k, long kb, double *kick_info, double tphysf, int kprev0, int kprev1, double *VKO);
 void cp_binmemb_to_star(long k, int kbi, long knew);
 void cp_SEvars_to_newstar(long oldk, int kbi, long knew);
 void cp_m_to_newstar(long oldk, int kbi, long knew);
@@ -1934,7 +1934,7 @@ void cp_starSEvars_to_binmember(star_t instar, long binindex, int bid);
 void cp_starmass_to_binmember(star_t instar, long binindex, int bid);
 void integrate_a_e_peters_eqn(long binidx);
 double r_of_m(double M);
-void cmc_bse_comenv(binary_t *tempbinary, double cmc_l_unit, double RbloodySUN, double *zpars, double *vs, int *fb);
+void cmc_bse_comenv(binary_t *tempbinary, double cmc_l_unit, double RbloodySUN, double *zpars, double *kick_info, int *fb);
 
 /* Fewbody stuff */
 void destroy_obj(long i);
@@ -1990,7 +1990,7 @@ void zero_star(long j);
 void zero_binary(long j);
 
 void sscollision_do(long k, long kp, double rperi, double w[4], double W, double rcm, double vcm[4], gsl_rng *rng);
-void merge_two_stars(star_t *star1, star_t *star2, star_t *merged_star, double *vs, struct rng_t113_state* s);
+void merge_two_stars(star_t *star1, star_t *star2, star_t *merged_star, double *kick_info, struct rng_t113_state* s);
 double coll_CE(double Mrg, double Mint, double Mwd, double Rrg, double vinf);
 double coll_CE_twogiant(double M1, double M2, double Mc1, double Mc2, double R1, double R2, double vinf);
 void NS_TDE_spinup(double Mns, double Mstar, double Rstar, double Kstar, double B_old, double ospin_old, double TDE_arr[]);

--- a/include/cmc/cmc.h
+++ b/include/cmc/cmc.h
@@ -1923,7 +1923,7 @@ void stellar_evolution_init(void);
 void restart_stellar_evolution(void);
 void do_stellar_evolution(gsl_rng *rng);
 void write_stellar_data(void);
-void handle_bse_outcome(long k, long kb, double *kick_info, double tphysf, int kprev0, int kprev1, double *VKO);
+void handle_bse_outcome(long k, long kb, double kick_info[19][2], double tphysf, int kprev0, int kprev1, double *VKO);
 void cp_binmemb_to_star(long k, int kbi, long knew);
 void cp_SEvars_to_newstar(long oldk, int kbi, long knew);
 void cp_m_to_newstar(long oldk, int kbi, long knew);
@@ -1934,7 +1934,7 @@ void cp_starSEvars_to_binmember(star_t instar, long binindex, int bid);
 void cp_starmass_to_binmember(star_t instar, long binindex, int bid);
 void integrate_a_e_peters_eqn(long binidx);
 double r_of_m(double M);
-void cmc_bse_comenv(binary_t *tempbinary, double cmc_l_unit, double RbloodySUN, double *zpars, double *kick_info, int *fb);
+void cmc_bse_comenv(binary_t *tempbinary, double cmc_l_unit, double RbloodySUN, double *zpars, double kick_info[19][2], int *fb);
 
 /* Fewbody stuff */
 void destroy_obj(long i);
@@ -1990,7 +1990,7 @@ void zero_star(long j);
 void zero_binary(long j);
 
 void sscollision_do(long k, long kp, double rperi, double w[4], double W, double rcm, double vcm[4], gsl_rng *rng);
-void merge_two_stars(star_t *star1, star_t *star2, star_t *merged_star, double *kick_info, struct rng_t113_state* s);
+void merge_two_stars(star_t *star1, star_t *star2, star_t *merged_star, double kick_info[19][2], struct rng_t113_state* s);
 double coll_CE(double Mrg, double Mint, double Mwd, double Rrg, double vinf);
 double coll_CE_twogiant(double M1, double M2, double Mc1, double Mc2, double R1, double R2, double vinf);
 void NS_TDE_spinup(double Mns, double Mstar, double Rstar, double Kstar, double B_old, double ospin_old, double TDE_arr[]);

--- a/include/cmc/cmc.h
+++ b/include/cmc/cmc.h
@@ -860,6 +860,31 @@ typedef struct{
 * @brief stellar evolution (0=off, 1=on)
 */
 	int STELLAR_EVOLUTION;
+#define PARAMDOC_STELLAR_ENGINE "stellar evolution engine (0=SSE Hurley fits, 1=METISSE interpolated tracks)"
+/**
+* @brief stellar evolution engine (0=SSE, 1=METISSE)
+*/
+	int STELLAR_ENGINE;
+#define PARAMDOC_PATH_TO_TRACKS "directory of main-sequence METISSE tracks (required when STELLAR_ENGINE=metisse)"
+/**
+* @brief directory of main-sequence METISSE tracks
+*/
+	int PATH_TO_TRACKS;
+#define PARAMDOC_PATH_TO_HE_TRACKS "directory of helium-star METISSE tracks (required when STELLAR_ENGINE=metisse)"
+/**
+* @brief directory of helium-star METISSE tracks
+*/
+	int PATH_TO_HE_TRACKS;
+#define PARAMDOC_Z_MATCH_LIMIT "max relative metallicity tolerance for matching METISSE tracks (default 1e-2)"
+/**
+* @brief METISSE metallicity match tolerance
+*/
+	int Z_MATCH_LIMIT;
+#define PARAMDOC_METISSE_VERBOSE "enable verbose METISSE diagnostic output (0=off, 1=on)"
+/**
+* @brief METISSE verbose output flag
+*/
+	int METISSE_VERBOSE;
 #define PARAMDOC_TIDAL_TREATMENT "choose the tidal cut-off criteria (0=radial criteria, 1=Giersz energy criteria)"
 /**
 * @brief choose the tidal cut-off criteria (0=radial criteria, 1=Giersz energy criteria)

--- a/include/cmc/cmc_vars.h
+++ b/include/cmc/cmc_vars.h
@@ -59,6 +59,12 @@ _EXTERN_ struct CenMa cenma;
 _EXTERN_ char MASS_PC[1000], MASS_BINS[1000], INPUT_FILE[1000], BSE_QCRIT_ARRAY[1000], BSE_NATAL_KICK_ARRAY[1000], BSE_FPRIMC_ARRAY[1000];
 _EXTERN_ char *TT_FILE;
 _EXTERN_ char *DF_FILE;
+/* COSMIC 4.0 stellar-evolution engine selection (SSE vs. METISSE) */
+_EXTERN_ long STELLAR_ENGINE;       /* 0 = SSE, 1 = METISSE */
+_EXTERN_ char *PATH_TO_TRACKS;      /* METISSE main-sequence track dir */
+_EXTERN_ char *PATH_TO_HE_TRACKS;   /* METISSE helium-star track dir */
+_EXTERN_ double Z_MATCH_LIMIT;      /* METISSE metallicity match tolerance */
+_EXTERN_ long METISSE_VERBOSE;      /* 0 = off, 1 = on */
 _EXTERN_ char *SNAPSHOT_WINDOWS;
 _EXTERN_ char *SNAPSHOT_WINDOW_UNITS;
 _EXTERN_ int MASS_PC_BH_INCLUDE;

--- a/src/bse_wrap/bse/CMakeLists.txt
+++ b/src/bse_wrap/bse/CMakeLists.txt
@@ -1,8 +1,84 @@
-# add library
-add_library(bse STATIC ./COSMIC/src/cosmic/src/comenv.f ./COSMIC/src/cosmic/src/corerd.f ./COSMIC/src/cosmic/src/deltat.f ./COSMIC/src/cosmic/src/dgcore.f ./COSMIC/src/cosmic/src/evolv1.f ./COSMIC/src/cosmic/src/evolv2.f ./COSMIC/src/cosmic/src/gntage.f ./COSMIC/src/cosmic/src/hrdiag.f ./COSMIC/src/cosmic/src/instar.f ./COSMIC/src/cosmic/src/kick.f ./COSMIC/src/cosmic/src/mix.f ./COSMIC/src/cosmic/src/mlwind.f ./COSMIC/src/cosmic/src/mrenv.f ./COSMIC/src/cosmic/src/rl.f ./COSMIC/src/cosmic/src/star.f ./COSMIC/src/cosmic/src/zcnsts.f ./COSMIC/src/cosmic/src/zfuncs.f ./COSMIC/src/cosmic/src/concatkstars.f ./COSMIC/src/cosmic/src/bpp_array.f ./COSMIC/src/cosmic/src/checkstate.f ./COSMIC/src/cosmic/src/int64.f ./COSMIC/src/cosmic/src/tausworth.f ./COSMIC/src/cosmic/src/taus113-ran3.f ./COSMIC/src/cosmic/src/hrdiag_remnant.f ./COSMIC/src/cosmic/src/hrdiag.f ./COSMIC/src/cosmic/src/instar.f ./COSMIC/src/cosmic/src/kick.f ./COSMIC/src/cosmic/src/mix.f ./COSMIC/src/cosmic/src/mlwind.f ./COSMIC/src/cosmic/src/mrenv.f ./COSMIC/src/cosmic/src/rl.f ./COSMIC/src/cosmic/src/star.f ./COSMIC/src/cosmic/src/zcnsts.f ./COSMIC/src/cosmic/src/zfuncs.f ./COSMIC/src/cosmic/src/concatkstars.f ./COSMIC/src/cosmic/src/bpp_array.f ./COSMIC/src/cosmic/src/checkstate.f ./COSMIC/src/cosmic/src/int64.f ./COSMIC/src/cosmic/src/tausworth.f ./COSMIC/src/cosmic/src/taus113-ran3.f ./COSMIC/src/cosmic/src/assign_remnant.f  )
+# BSE/COSMIC + SSE + METISSE Fortran sources.
+# Tracks COSMIC's src/cosmic/meson.build lib_source list. Keep in sync when bumping the submodule.
 
-# Include paths to headers
-include_directories (./COSMIC/src/cosmic/src/)
+set(COSMIC_SRC ./COSMIC/src/cosmic/src)
+
+set(COSMIC_CORE_SOURCES
+    ${COSMIC_SRC}/hrdiag_remnant.f
+    ${COSMIC_SRC}/assign_remnant.f
+    ${COSMIC_SRC}/benchmarkevolv2.f
+    ${COSMIC_SRC}/int64.f
+    ${COSMIC_SRC}/corerd.f
+    ${COSMIC_SRC}/comenv.f
+    ${COSMIC_SRC}/dgcore.f
+    ${COSMIC_SRC}/evolv2.f
+    ${COSMIC_SRC}/gntage.f
+    ${COSMIC_SRC}/instar.f
+    ${COSMIC_SRC}/kick.f
+    ${COSMIC_SRC}/mix.f
+    ${COSMIC_SRC}/mrenv.f
+    # ran3.f intentionally excluded — CMC's taus113-ran3.f provides
+    # ran3 (Tausworth) plus the RandomNormal/RandomTruncatedNormal
+    # helpers that the rest of COSMIC's Fortran calls.
+    ${COSMIC_SRC}/rl.f
+    ${COSMIC_SRC}/hrdiag.f
+    ${COSMIC_SRC}/star.f
+    ${COSMIC_SRC}/concatkstars.f
+    ${COSMIC_SRC}/comprad.f
+    ${COSMIC_SRC}/bpp_array.f
+    ${COSMIC_SRC}/checkstate.f
+    ${COSMIC_SRC}/deltat.f
+    ${COSMIC_SRC}/mlwind.f
+    ${COSMIC_SRC}/zcnsts.f
+)
+
+# CMC-owned Tausworth RNG sources. taus113-ran3.f provides ran3 (overrides
+# COSMIC's NR ran3 via linker symbol resolution) plus RandomNormal and
+# RandomTruncatedNormal (which the rest of COSMIC's Fortran calls).
+# tausworth.f / tausworth.h provide the Tausworth-113 helpers.
+set(CMC_TAUSWORTH_SOURCES
+    ${CMAKE_CURRENT_SOURCE_DIR}/tausworth.f
+    ${CMAKE_CURRENT_SOURCE_DIR}/taus113-ran3.f
+)
+
+set(SSE_SOURCES
+    ${COSMIC_SRC}/SSE/SSE_deltat.f
+    ${COSMIC_SRC}/SSE/SSE_mlwind.f
+    ${COSMIC_SRC}/SSE/SSE_hrdiag.f
+    ${COSMIC_SRC}/SSE/SSE_star.f
+    ${COSMIC_SRC}/SSE/SSE_zcnsts.f
+    ${COSMIC_SRC}/SSE/SSE_zfuncs.f
+    ${COSMIC_SRC}/SSE/SSE_gntage.f
+)
+
+set(METISSE_SOURCES
+    ${COSMIC_SRC}/METISSE/src/track_support.f90
+    ${COSMIC_SRC}/METISSE/src/c_m_interface.f90
+    ${COSMIC_SRC}/METISSE/src/METISSE_gntage.f90
+    ${COSMIC_SRC}/METISSE/src/METISSE_deltat.f90
+    ${COSMIC_SRC}/METISSE/src/METISSE_mlwind.f90
+    ${COSMIC_SRC}/METISSE/src/METISSE_hrdiag.f90
+    ${COSMIC_SRC}/METISSE/src/METISSE_star.f90
+    ${COSMIC_SRC}/METISSE/src/METISSE_zcnsts.f90
+    ${COSMIC_SRC}/METISSE/src/z_support.f90
+    ${COSMIC_SRC}/METISSE/src/sse_support.f90
+    ${COSMIC_SRC}/METISSE/src/remnant_support.f90
+    ${COSMIC_SRC}/METISSE/src/interp_support.f90
+    ${COSMIC_SRC}/METISSE/src/comenv_lambda.f90
+    ${COSMIC_SRC}/METISSE/src/METISSE_miscellaneous.f90
+    ${COSMIC_SRC}/METISSE_utils.f90
+)
+
+add_library(bse STATIC
+    ${COSMIC_CORE_SOURCES}
+    ${CMC_TAUSWORTH_SOURCES}
+    ${SSE_SOURCES}
+    ${METISSE_SOURCES}
+)
+
+# Include paths to headers. CMC's dir first so our tausworth.h overrides
+# COSMIC's stale copy; COSMIC's dir still provides int64.h and const_bse.h.
+include_directories(${CMAKE_CURRENT_SOURCE_DIR} ${COSMIC_SRC})
 
 install(TARGETS bse DESTINATION lib)
 

--- a/src/bse_wrap/bse/taus113-ran3.f
+++ b/src/bse_wrap/bse/taus113-ran3.f
@@ -1,0 +1,111 @@
+C ====================================================================
+C     This function is a drop-in replacement for the ran3 random
+C     number generator from Numerical Recipes, Press et al.
+C     It is based on E'cuyer's combined Tausworth generator with
+C     period 2**113.
+C
+C ====================================================================
+      real function ran3(IDUM)
+        implicit none
+        include "tausworth.h"
+        integer(kind=int64) state(4), rnumber, taus113_gen_int
+        integer i, IDUM, first, tid
+c$      integer OMP_GET_THREAD_NUM
+        COMMON/Taus113State/ state, first
+        SAVE /Taus113State/
+!$OMP THREADPRIVATE(/Taus113State/)
+        EXTERNAL taus113_gen_int
+
+        if(IDUM.lt.0) then
+          call taus113_seeding(state, -IDUM)
+C         The "warm-up" that has been left out in the seeding routine:
+          print*, "Combined Tausworth 113 Generator warming up."
+          do i=1,10
+            call taus113_next_state(state)
+          end do
+          IDUM= -IDUM
+        endif
+
+        call taus113_next_state(state)
+        rnumber= taus113_gen_int(state)
+
+        if (first.eq.1) then
+          tid= 1
+c$        tid= OMP_GET_THREAD_NUM()
+          first=0
+          print("('taus-ran3: TID',I2,' The first random number is ',
+     &    G16.8)"), tid, real(dble(rnumber)/dble(umax))
+        endif
+
+        ran3= real(dble(rnumber)/dble(umax))
+      end function
+
+      subroutine taus113_ran3_tester()
+        integer i, failcount
+        logical passed
+        real rnumber, ran3
+        external ran3
+
+        passed=.true.
+        failcount=0
+        rnumber=ran3(-123456)
+        do i=1,1000000000
+          if (rnumber>=1.e0) then
+            passed=.false.
+            failcount= failcount + 1
+            print*, "FOUL!!", rnumber-1.0e0, rnumber==1.e0, failcount, i
+          end if
+          rnumber=ran3(123456)
+        end do
+      end subroutine
+
+C ====================================================================
+C     RandomNormal and RandomTruncatedNormal — extracted from COSMIC's
+C     src/cosmic/src/ran3.f. COSMIC's kick.f and assign_remnant.f call
+C     these. We bundle them with our Tausworth ran3 so the internal
+C     ran3() calls below resolve to the parallel-safe RNG (which is
+C     critical correctness — NR's single-stream ran3 would correlate
+C     draws across MPI ranks).
+C ====================================================================
+
+      SUBROUTINE RandomNormal(mean, sigma, idum, result)
+* Generate a normally distributed random number with given mean and sigma
+* using the Box-Muller transform
+
+      real*8 mean, sigma, result
+      integer idum
+      real*8 u1, u2, Z0
+
+      u1 = ran3(idum)
+      u2 = ran3(idum)
+      Z0 = SQRT(-2.d0*LOG(u1))*COS(2.d0*3.141592653589793d0*u2)
+      result = Z0 * sigma + mean
+
+      RETURN
+      END
+
+
+      SUBROUTINE RandomTruncatedNormal(mu, sigma, idum, lower, upper, x)
+* Generate a random number from a truncated normal distribution
+* with mean mu, standard deviation sigma, truncated to [lower, upper]
+      IMPLICIT NONE
+      REAL*8 mu, sigma, lower, upper, x
+      INTEGER idum, max_attempts, attempt
+
+      attempt = 0
+      max_attempts = 1000
+
+      do
+          attempt = attempt + 1
+          call RandomNormal(mu, sigma, idum, x)
+          if (x .GE. lower .AND. x .LE. upper)then
+             exit
+          elseif (attempt.ge.max_attempts) then
+            ! use the midpoint if we exceed max attempts
+            x = 0.5d0 * (lower + upper)
+            exit
+          endif
+      end do
+
+      RETURN
+      END

--- a/src/bse_wrap/bse/tausworth.f
+++ b/src/bse_wrap/bse/tausworth.f
@@ -1,0 +1,84 @@
+      BLOCK DATA Taus113_init
+        include "tausworth.h"
+        DATA c /z'fffffffe', z'fffffff8', z'fffffff0', z'ffffff80'/
+        DATA cseed /69069/
+      END
+
+      subroutine taus113_seeding(z, seed)
+        include "tausworth.h"
+        integer(kind=int64) z(4), seed
+
+        print*, umax, bit_size(umax)
+
+        z(1) = iand(umax, seed * cseed)
+        if ( z(1) < 2 ) z(1) = z(1) + 2
+        z(2) = iand(umax, z(1) * cseed)
+        if ( z(2) < 8 ) z(2) = z(2) + 8
+        z(3) = iand(umax, z(2) * cseed)
+        if ( z(3) < 16 ) z(3) = z(3) + 16
+        z(4) = iand(umax, z(3) * cseed)
+        if ( z(4) < 128 ) z(4) = z(4) + 128
+      end subroutine
+
+      function ishft32(a, shift)
+        include "tausworth.h"
+        integer(kind=int64) ishft32, a
+        integer shift
+
+        ishft32= iand(ishft(a, shift), umax)
+      end function
+
+      subroutine taus113_next_state(z)
+        include "tausworth.h"
+        integer(kind=int64) z(4), znew(4), ishft32
+        EXTERNAL ishft32
+        integer i
+
+        znew(1)  = ishft32(iand(z(1),c(1)), 18)
+        znew(2)  = ishft32(iand(z(2),c(2)), 2)
+        znew(3)  = ishft32(iand(z(3),c(3)), 7)
+        znew(4)  = ishft32(iand(z(4),c(4)),13)
+
+        znew(1) = ieor(znew(1), ishft(ieor(ishft32(z(1),6), z(1)),-13))
+        znew(2) = ieor(znew(2), ishft(ieor(ishft32(z(2),2), z(2)),-27))
+        znew(3) = ieor(znew(3), ishft(ieor(ishft32(z(3),13), z(3)),-21))
+        znew(4) = ieor(znew(4), ishft(ieor(ishft32(z(4),3), z(4)),-12))
+
+        do i=1,4
+          z(i)=znew(i)
+        end do
+      end subroutine
+
+      function taus113_gen_int(z)
+        include "tausworth.h"
+        integer(kind=int64) taus113_gen_int, z(4), rnum
+
+        rnum= z(1)
+        do i=2,4
+          rnum= ieor(rnum, z(i))
+        end do
+
+        taus113_gen_int= rnum
+      end function
+
+      subroutine test_taus()
+        include "int64.h"
+        integer(kind=int64) taus113_gen_int
+        EXTERNAL taus113_gen_int
+        integer(kind=int64) i, z(4), znew(4), seed, maxiter
+
+        seed= 123456
+        call taus113_seeding(z, seed)
+
+        maxiter= int(1d9)
+        do i=1,maxiter
+          call taus113_next_state(z)
+        end do
+
+        print*, bit_size(seed), seed, umax
+        do i=1,4
+          print*, "z(",i,")=", z(i)
+        enddo
+        print*, taus113_gen_int(z)
+      end subroutine
+

--- a/src/bse_wrap/bse/tausworth.h
+++ b/src/bse_wrap/bse/tausworth.h
@@ -1,0 +1,4 @@
+        include "int64.h"
+        COMMON/Taus113Consts/ c, cseed
+        integer(kind=int64) c(4), cseed
+        SAVE /Taus113Consts/

--- a/src/bse_wrap/bse_wrap.c
+++ b/src/bse_wrap/bse_wrap.c
@@ -38,7 +38,7 @@ void bse_zcnsts(double *z, double *zpars)
 void bse_evolve_single(int *kw, double *mass, double *mt, double *r, double *lum,
 		double *mc, double *rc, double *menv, double *renv, double *ospin,
 		double *epoch, double *tms, double *tphys, double *tphysf,
-		double *dtp, double *z, double *zpars, double *kick_info, double *bhspin) {
+		double *dtp, double *z, double *zpars, double kick_info[19][2], double *bhspin) {
   bse_binary tempbinary;
 
   tempbinary.bse_mass0[0] = *mass;
@@ -138,7 +138,7 @@ void bse_evolv2(int *kstar, double *mass0, double *mass, double *rad, double *lu
 		double *massc, double *radc, double *menv, double *renv, double *ospin,
                 double *B_0, double *bacc, double *tacc,
 		double *epoch, double *tms, double *tphys, double *tphysf, double *dtp,
-		double *z, double *zpars, double *tb, double *ecc, double *kick_info, double *bhspin)
+		double *z, double *zpars, double *tb, double *ecc, double kick_info[19][2], double *bhspin)
 {
     int i, j;
     //double kick_info[19][2];
@@ -191,7 +191,7 @@ void bse_evolv2_safely(int *kstar, double *mass0, double *mass, double *rad, dou
 		       double *massc, double *radc, double *menv, double *renv, double *ospin,
                        double *B_0, double *bacc, double *tacc,
 		       double *epoch, double *tms, double *tphys, double *tphysf, double *dtp,
-		       double *z, double *zpars, double *tb, double *ecc, double *kick_info, double *bhspin)
+		       double *z, double *zpars, double *tb, double *ecc, double kick_info[19][2], double *bhspin)
 {
   int mykstar[2], mykstarprev[2], kattempt=-1, j, i;
   double mymass0[2], mymass[2], myrad[2], mylum[2], mymassc[2], myradc[2], mymenv[2], myrenv[2], myospin[2], myB_0[2], mybacc[2], mytacc[2], myepoch[2];
@@ -424,7 +424,7 @@ void bse_hrdiag(double *mass, double *aj, double *mt, double *tm, double *tn, do
      replace vs with kick_info to be more consistent with the kick output from COSMIC (CSY)
 */
 void bse_kick(int *kw, double *m1, double *m1n, double *m2, double *ecc, double *sep,
-	      double *jorb, double *vk, int *snstar, double *r2, double *fallback, double *kick_info)
+	      double *jorb, double *vk, int *snstar, double *r2, double *fallback, double kick_info[19][2])
 {
   /* INPUTS
      kw = stellar type
@@ -493,7 +493,7 @@ void bse_mix(double *mass, double *mt, double *aj, int *kw, double *zpars, doubl
 * @param ecsnp ?
 * @param ecsn_mlow ?
 */
-void bse_comenv(bse_binary *tempbinary, double *zpars, double *kick_info, int *fb)
+void bse_comenv(bse_binary *tempbinary, double *zpars, double kick_info[19][2], int *fb)
 		//double *M0, double *M, double *MC, double *AJ, double *OSPIN, int *KW,
 		//                double *M02, double *M2, double *MC2, double *AJ2, double *JSPIN2, int *KW2,
                 //double *ZPARS, double *ECC, double *SEP, double *PORB,

--- a/src/bse_wrap/bse_wrap.c
+++ b/src/bse_wrap/bse_wrap.c
@@ -455,15 +455,9 @@ void bse_kick(int *kw, double *m1, double *m1n, double *m2, double *ecc, double 
    */
   /* LOGICAL used by COSMIC, but not needed here */
     int disrupt=0;
-    //double kick_info[19][2];
-    //int i, j ;
+    double tphys=0.0;
 
-    //for(i=0;i<19;i++) {
-    //    for(j=0;j<2;j++){
-    //        kick_info[i][j] = 0.0;
-    //    }
-    //}
-    kick_(kw, m1, m1n, m2, ecc, sep, jorb, vk, snstar, r2, fallback, &snvars_.sigma, kick_info, &disrupt);
+    kick_(kw, m1, m1n, m1n, m2, ecc, sep, jorb, vk, snstar, r2, fallback, &snvars_.sigma, kick_info, &disrupt, &tphys);
 }
 
 /**
@@ -504,7 +498,7 @@ void bse_comenv(bse_binary *tempbinary, double *zpars, double kick_info[19][2], 
   double bhspin[2];
   int binstate=0, mergertype=0;
   int jp=0,switchedCE=0, disrupt=0;
-  double tphys=0, evolve_type=0;
+  double tphys, evolve_type=0;
   double tms[2], rad[2], lumin[2], B_0[2], bacc[2], tacc[2], epoch[2], menv_bpp[2], renv_bpp[2];
   //double kick_info[18][2];
 
@@ -579,17 +573,7 @@ void bse_comenv(bse_binary *tempbinary, double *zpars, double kick_info[19][2], 
           kick_info[i][j] = 0.0;
       }
   }
-  ////
-  //// Why we are here:
-  ////
-  //  COMENV_((tempbinary.bse_mass0[0]), (tempbinary.bse_mass[0]), (tempbinary.bse_massc[0]), &(AJ[0]), &JSPIN1, (tempbinary.bse_kw[0]),
-  //	  (tempbinary.bse_mass0[1]), (tempbinary.bse_mass[1]), (tempbinary.bse_massc[1]), &(AJ[1]), &JSPIN2, (tempbinary.bse_kw[1]),
-  //	  zpars, (tempbinary.e), (tempbinary.a), &(JORB), &COEL, &star1, &star2, &vk, fb, vs, ecsnp, ecsn_mlow, &(tempbinary.bse_bcm_formation[0]), &(tempbinary.bse_bcm_formation[1]), ST_tide);
-  //printf("bse_wrap ZPARS: \n");
-  //for(iii=0;iii<20; iii++){
-  //  printf("%g ", zpars[iii]);
-  //}
-  //printf(" kw1i=%d kw2i=%d m1i=%g m2i=%g r1i=%g r2i=%g epoch1=%g epoch2=%g ", (*tempbinary).bse_kw[0], (*tempbinary).bse_kw[1], (*tempbinary).bse_mass[0], (*tempbinary).bse_mass[1], (*tempbinary).bse_radius[0], (*tempbinary).bse_radius[1], (*tempbinary).bse_epoch[0], (*tempbinary).bse_epoch[1]);
+  tphys = (*tempbinary).bse_tphys;
   /* deltam_1, deltam_2, dtm are METISSE-only; SSE path ignores them. */
   double comenv_deltam_1 = 0.0, comenv_deltam_2 = 0.0, comenv_dtm = 0.0;
   comenv_(&((*tempbinary).bse_mass0[0]), &((*tempbinary).bse_mass[0]), &((*tempbinary).bse_massc[0]), &(AJ[0]), &JSPIN1, &((*tempbinary).bse_kw[0]),

--- a/src/bse_wrap/bse_wrap.c
+++ b/src/bse_wrap/bse_wrap.c
@@ -20,6 +20,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include <math.h>
 #include "bse_wrap.h"
 
@@ -656,6 +657,32 @@ void bse_comenv(bse_binary *tempbinary, double *zpars, double *vs, int *fb)
 void bse_set_using_cmc(void) {cmcpass_.using_cmc = 1; }
 void bse_set_idum(int idum) { rand1_.idum1 = idum; }
 void bse_init_umax(void) { integers_.umax = 0xFFFFFFFFLL; }
+
+/* COSMIC 4.0 stellar-evolution engine selector.
+ * stellar_engine: 0 = SSE (using_sse=1, using_metisse=0), 1 = METISSE (inverse).
+ * MUST be called before bse_zcnsts(); otherwise both flags default to 0 in the
+ * SE_FLAGS COMMON block and the dispatchers in deltat.f / mlwind.f / hrdiag.f
+ * silently no-op (uninitialized dt/dtr, etc.). */
+void bse_set_stellar_engine(int stellar_engine) {
+	if (stellar_engine == 1) {
+		se_flags_.using_metisse = 1;
+		se_flags_.using_sse = 0;
+	} else {
+		se_flags_.using_metisse = 0;
+		se_flags_.using_sse = 1;
+	}
+}
+
+/* Populate the METISSEVARS COMMON block. Only meaningful when STELLAR_ENGINE=1.
+ * COSMIC's METISSE_utils.f90 strips trailing NUL via get_csafe_string, so a
+ * standard NUL-terminated C string into the 256-char buffer works. */
+void bse_set_metisse_inputs(char *path_to_tracks, char *path_to_he_tracks,
+                            double z_match_limit, int metisse_verbose) {
+	if (path_to_tracks    != NULL) strncpy(metissevars_.path_to_tracks,    path_to_tracks,    256);
+	if (path_to_he_tracks != NULL) strncpy(metissevars_.path_to_he_tracks, path_to_he_tracks, 256);
+	metissevars_.z_match_limit   = z_match_limit;
+	metissevars_.metisse_verbose = metisse_verbose;
+}
 void bse_set_eddlimflag(int eddlimflag) { flags_.eddlimflag = eddlimflag; }
 void bse_set_sigmadiv(double sigmadiv) { snvars_.sigmadiv = sigmadiv; }
 

--- a/src/bse_wrap/bse_wrap.c
+++ b/src/bse_wrap/bse_wrap.c
@@ -655,6 +655,7 @@ void bse_comenv(bse_binary *tempbinary, double *zpars, double *vs, int *fb)
 //OPT: Use inline before void -> makes it macro
 void bse_set_using_cmc(void) {cmcpass_.using_cmc = 1; }
 void bse_set_idum(int idum) { rand1_.idum1 = idum; }
+void bse_init_umax(void) { integers_.umax = 0xFFFFFFFFLL; }
 void bse_set_eddlimflag(int eddlimflag) { flags_.eddlimflag = eddlimflag; }
 void bse_set_sigmadiv(double sigmadiv) { snvars_.sigmadiv = sigmadiv; }
 

--- a/src/bse_wrap/bse_wrap.c
+++ b/src/bse_wrap/bse_wrap.c
@@ -318,6 +318,7 @@ void bse_evolv2_safely(int *kstar, double *mass0, double *mass, double *rad, dou
           kick_info[i][j] = mykick_info[i][j];
       }
   }  
+
 }
 
 

--- a/src/bse_wrap/bse_wrap.c
+++ b/src/bse_wrap/bse_wrap.c
@@ -38,7 +38,7 @@ void bse_zcnsts(double *z, double *zpars)
 void bse_evolve_single(int *kw, double *mass, double *mt, double *r, double *lum,
 		double *mc, double *rc, double *menv, double *renv, double *ospin,
 		double *epoch, double *tms, double *tphys, double *tphysf,
-		double *dtp, double *z, double *zpars, double *vs, double *bhspin) {
+		double *dtp, double *z, double *zpars, double *kick_info, double *bhspin) {
   bse_binary tempbinary;
 
   tempbinary.bse_mass0[0] = *mass;
@@ -81,7 +81,7 @@ void bse_evolve_single(int *kw, double *mass, double *mt, double *r, double *lum
       &(tempbinary.bse_radc[0]), &(tempbinary.bse_menv[0]), &(tempbinary.bse_renv[0]),
       &(tempbinary.bse_ospin[0]), &(tempbinary.bse_B_0[0]), &(tempbinary.bse_bacc[0]), &(tempbinary.bse_tacc[0]),
       &(tempbinary.bse_epoch[0]), &(tempbinary.bse_tms[0]),
-      tphys, tphysf, dtp, z, zpars, &(tempbinary.bse_tb), &(tempbinary.e), vs, &(tempbinary.bse_bhspin[0]));
+      tphys, tphysf, dtp, z, zpars, &(tempbinary.bse_tb), &(tempbinary.e), kick_info, &(tempbinary.bse_bhspin[0]));
 
   *mass = tempbinary.bse_mass0[0];
   *kw = tempbinary.bse_kw[0];
@@ -123,7 +123,7 @@ void bse_evolve_single(int *kw, double *mass, double *mt, double *r, double *lum
 * @param zpars ?
 * @param tb ?
 * @param ecc ?
-* @param vs ?
+* @param kick_info ?
 */
 /* Last-write-wins index of the most recent valid bcm/bpp row, as reported
  * by evolv2's out args. Replaces the legacy "walk until tphys<0 sentinel"
@@ -138,21 +138,12 @@ void bse_evolv2(int *kstar, double *mass0, double *mass, double *rad, double *lu
 		double *massc, double *radc, double *menv, double *renv, double *ospin,
                 double *B_0, double *bacc, double *tacc,
 		double *epoch, double *tms, double *tphys, double *tphysf, double *dtp,
-		double *z, double *zpars, double *tb, double *ecc, double *vs, double *bhspin)
+		double *z, double *zpars, double *tb, double *ecc, double *kick_info, double *bhspin)
 {
-    /* must null out vs, since SSE/BSE is not designed to return it and hence doesn't null it out */
-    /*  vs[0] = 0.0;
-    vs[1] = 0.0;
-    vs[2] = 0.0; */
-	int i, j;
-    for(i=0;i<20;i++) {
-        vs[i] = 0.0;
-    }
+    int i, j;
+    //double kick_info[19][2];
 
-    double kick_info[18][2];
-
-
-    for(i=0;i<18;i++) {
+    for(i=0;i<19;i++) {
         for(j=0;j<2;j++){
             kick_info[i][j] = 0.0;
         }
@@ -162,10 +153,8 @@ void bse_evolv2(int *kstar, double *mass0, double *mass, double *rad, double *lu
      * cached into bse_last_*_index for handle_bse_outcome via getters. */
     int bpp_index_out = 0;
     int bcm_index_out = 0;
-    double kick_info_out[18][2];
-    for (i = 0; i < 18; i++) { kick_info_out[i][0] = 0.0; kick_info_out[i][1] = 0.0; }
 
-    evolv2_(kstar,mass,tb,ecc,z,tphysf,dtp,mass0,rad,lum,massc,radc, menv,renv,ospin,B_0,bacc,tacc,epoch,tms,bhspin,tphys,zpars,vs, *kick_info, &bpp_index_out, &bcm_index_out, *kick_info_out);
+    evolv2_(kstar,mass,tb,ecc,z,tphysf,dtp,mass0,rad,lum,massc,radc, menv,renv,ospin,B_0,bacc,tacc,epoch,tms,bhspin,tphys,zpars, kick_info, &bpp_index_out, &bcm_index_out);
 
     bse_last_bcm_index = bcm_index_out;
     bse_last_bpp_index = bpp_index_out;
@@ -196,17 +185,17 @@ void bse_evolv2(int *kstar, double *mass0, double *mass, double *rad, double *lu
 * @param zpars ?
 * @param tb ?
 * @param ecc ?
-* @param vs ?
+* @param kick_info ?
 */
 void bse_evolv2_safely(int *kstar, double *mass0, double *mass, double *rad, double *lum,
 		       double *massc, double *radc, double *menv, double *renv, double *ospin,
                        double *B_0, double *bacc, double *tacc,
 		       double *epoch, double *tms, double *tphys, double *tphysf, double *dtp,
-		       double *z, double *zpars, double *tb, double *ecc, double *vs, double *bhspin)
+		       double *z, double *zpars, double *tb, double *ecc, double *kick_info, double *bhspin)
 {
   int mykstar[2], mykstarprev[2], kattempt=-1, j, i;
   double mymass0[2], mymass[2], myrad[2], mylum[2], mymassc[2], myradc[2], mymenv[2], myrenv[2], myospin[2], myB_0[2], mybacc[2], mytacc[2], myepoch[2];
-  double mytms[2], mytphys, mytphysf, mydtp, tphystried, mytb, myecc, myvs[20], mybhspin[2];
+  double mytms[2], mytphys, mytphysf, mydtp, tphystried, mytb, myecc, mykick_info[19][2], mybhspin[2];
 
   //  do {
     kattempt++;
@@ -243,7 +232,7 @@ void bse_evolv2_safely(int *kstar, double *mass0, double *mass, double *rad, dou
     mytb = *tb;
     myecc = *ecc;
     bse_evolv2(mykstar, mymass0, mymass, myrad, mylum, mymassc, myradc, mymenv, myrenv, myospin, myB_0, mybacc, mytacc,
-	       myepoch, mytms, &mytphys, &mytphysf, &mydtp, z, zpars, &mytb, &myecc, myvs, mybhspin);
+	       myepoch, mytms, &mytphys, &mytphysf, &mydtp, z, zpars, &mytb, &myecc, mykick_info, mybhspin);
     /*
   } while ((isnan(myrad[0]) || mymassc[0] < 0.0 || mymass[0] < 0.0 || mymass0[0] < 0.0 || mylum[0] < 0.0 ||
 	    isnan(myrad[1]) || mymassc[1] < 0.0 || mymass[1] < 0.0 || mymass0[1] < 0.0 || mylum[1] < 0.0) && tphystried > 0.0);
@@ -321,9 +310,14 @@ void bse_evolv2_safely(int *kstar, double *mass0, double *mass, double *rad, dou
 /*  vs[0] = myvs[0];
   vs[1] = myvs[1];
   vs[2] = myvs[2];*/
-  for(i=0;i<20;i++) {
-      vs[i] = myvs[i];
-  }
+  //for(i=0;i<20;i++) {
+  //    vs[i] = myvs[i];
+  //}
+  for(i=0;i<19;i++) {
+      for(j=0;j<2;j++){
+          kick_info[i][j] = mykick_info[i][j];
+      }
+  }  
 }
 
 
@@ -427,9 +421,10 @@ void bse_hrdiag(double *mass, double *aj, double *mt, double *tm, double *tn, do
 * @param vs
      old -> vs = velocity (3) of center of mass if bound, relative velocity at infinity if unbound
      new -> vs = three possible sets of velocities (3). Is an array of 12, correctly accounts for
+     replace vs with kick_info to be more consistent with the kick output from COSMIC (CSY)
 */
 void bse_kick(int *kw, double *m1, double *m1n, double *m2, double *ecc, double *sep,
-	      double *jorb, double *vk, int *snstar, double *r2, double *fallback, double *vs)
+	      double *jorb, double *vk, int *snstar, double *r2, double *fallback, double *kick_info)
 {
   /* INPUTS
      kw = stellar type
@@ -456,18 +451,19 @@ void bse_kick(int *kw, double *m1, double *m1n, double *m2, double *ecc, double 
      output into one of the 3 velocity slots.
      Another 3 values within the array show which star (1 or 2) went SN for that kick.
      This helps in differentiating which kick goes where.
+     replace vs with kick_info. kick_info contains the same information, just different output structure. (CSY)
    */
   /* LOGICAL used by COSMIC, but not needed here */
     int disrupt=0;
-    double kick_info[18][2];
-    int i, j ;
+    //double kick_info[19][2];
+    //int i, j ;
 
-    for(i=0;i<18;i++) {
-        for(j=0;j<2;j++){
-            kick_info[i][j] = 0.0;
-        }
-    }
-    kick_(kw, m1, m1n, m2, ecc, sep, jorb, vk, snstar, r2, fallback, &snvars_.sigma, *kick_info, &disrupt, vs);
+    //for(i=0;i<19;i++) {
+    //    for(j=0;j<2;j++){
+    //        kick_info[i][j] = 0.0;
+    //    }
+    //}
+    kick_(kw, m1, m1n, m2, ecc, sep, jorb, vk, snstar, r2, fallback, &snvars_.sigma, kick_info, &disrupt);
 }
 
 /**
@@ -492,12 +488,12 @@ void bse_mix(double *mass, double *mt, double *aj, int *kw, double *zpars, doubl
 *
 * @param tempbinary ?
 * @param zpars ?
-* @param vs ?
+* @param kick_info ?
 * @param fb ?
 * @param ecsnp ?
 * @param ecsn_mlow ?
 */
-void bse_comenv(bse_binary *tempbinary, double *zpars, double *vs, int *fb)
+void bse_comenv(bse_binary *tempbinary, double *zpars, double *kick_info, int *fb)
 		//double *M0, double *M, double *MC, double *AJ, double *OSPIN, int *KW,
 		//                double *M02, double *M2, double *MC2, double *AJ2, double *JSPIN2, int *KW2,
                 //double *ZPARS, double *ECC, double *SEP, double *PORB,
@@ -510,13 +506,13 @@ void bse_comenv(bse_binary *tempbinary, double *zpars, double *vs, int *fb)
   int jp=0,switchedCE=0, disrupt=0;
   double tphys=0, evolve_type=0;
   double tms[2], rad[2], lumin[2], B_0[2], bacc[2], tacc[2], epoch[2], menv_bpp[2], renv_bpp[2];
-  double kick_info[18][2];
+  //double kick_info[18][2];
 
-  for(i=0;i<18;i++) {
-      for(j=0;j<2;j++){
-          kick_info[i][j] = 0.0;
-      }
-  }
+  //for(i=0;i<18;i++) {
+  //    for(j=0;j<2;j++){
+  //        kick_info[i][j] = 0.0;
+  //    }
+  //}
 
   k3 = 0.21;
   PI = acos(-1.0);
@@ -528,7 +524,7 @@ void bse_comenv(bse_binary *tempbinary, double *zpars, double *vs, int *fb)
   //  ST_tide tells code if StarTrack-like tides are assumed in code.
   //
   //  OUTPUTS
-  //  Final masses etc, ecc, sep, Porb will be modified in CE evolution, vs is an array that might be filled if a NS is formed, formations tell
+  //  Final masses etc, ecc, sep, Porb will be modified in CE evolution, kick_info is an array that might be filled if a NS is formed, formations tell
   //  the type of SN that occured (if one occured).
   //
   //
@@ -575,8 +571,13 @@ void bse_comenv(bse_binary *tempbinary, double *zpars, double *vs, int *fb)
   //     double *mc, double *rc, double *menv, double *renv, double *k2, int *ST_tide, double *ecsnp, double *ecsn_mlow)
   //
   vk = 0.0;
-  for(i=0;i<20;i++) {
-      vs[i] = 0.0;
+  //for(i=0;i<20;i++) {
+  //    vs[i] = 0.0;
+  //}
+  for(i=0;i<19;i++) {
+      for(j=0;j<2;j++){
+          kick_info[i][j] = 0.0;
+      }
   }
   ////
   //// Why we are here:
@@ -593,7 +594,7 @@ void bse_comenv(bse_binary *tempbinary, double *zpars, double *vs, int *fb)
   double comenv_deltam_1 = 0.0, comenv_deltam_2 = 0.0, comenv_dtm = 0.0;
   comenv_(&((*tempbinary).bse_mass0[0]), &((*tempbinary).bse_mass[0]), &((*tempbinary).bse_massc[0]), &(AJ[0]), &JSPIN1, &((*tempbinary).bse_kw[0]),
 	  &((*tempbinary).bse_mass0[1]), &((*tempbinary).bse_mass[1]), &((*tempbinary).bse_massc[1]), &(AJ[1]), &JSPIN2, &((*tempbinary).bse_kw[1]),
-	  zpars, &((*tempbinary).e), &((*tempbinary).a), &(JORB), &COEL, &star1, &star2, &vk, *kick_info, &((*tempbinary).bse_bcm_formation[0]), &((*tempbinary).bse_bcm_formation[1]), &snvars_.sigma, &((*tempbinary).bse_bhspin[0]),&((*tempbinary).bse_bhspin[1]),&binstate,&mergertype,&jp,&tphys,&switchedCE,rad,tms,&evolve_type,&disrupt,lumin,B_0,bacc,tacc,epoch,menv_bpp,renv_bpp,vs,&comenv_deltam_1,&comenv_deltam_2,&comenv_dtm);
+	  zpars, &((*tempbinary).e), &((*tempbinary).a), &(JORB), &COEL, &star1, &star2, &vk, kick_info, &((*tempbinary).bse_bcm_formation[0]), &((*tempbinary).bse_bcm_formation[1]), &snvars_.sigma, &((*tempbinary).bse_bhspin[0]),&((*tempbinary).bse_bhspin[1]),&binstate,&mergertype,&jp,&tphys,&switchedCE,rad,tms,&evolve_type,&disrupt,lumin,B_0,bacc,tacc,epoch,menv_bpp,renv_bpp,&comenv_deltam_1,&comenv_deltam_2,&comenv_dtm);
   //printf("kw1i=%d kw2i=%d m1f=%g m2f=%g r1f=%g r2f=%g ", (*tempbinary).bse_kw[0], (*tempbinary).bse_kw[1], (*tempbinary).bse_mass[0], (*tempbinary).bse_mass[1], (*tempbinary).bse_radius[0], (*tempbinary).bse_radius[1]);
   //printf("\n");
   ////

--- a/src/bse_wrap/bse_wrap.c
+++ b/src/bse_wrap/bse_wrap.c
@@ -124,6 +124,15 @@ void bse_evolve_single(int *kw, double *mass, double *mt, double *r, double *lum
 * @param ecc ?
 * @param vs ?
 */
+/* Last-write-wins index of the most recent valid bcm/bpp row, as reported
+ * by evolv2's out args. Replaces the legacy "walk until tphys<0 sentinel"
+ * scan in handle_bse_outcome — BSE no longer sentinel-terminates. */
+static int bse_last_bcm_index = 0;
+static int bse_last_bpp_index = 0;
+
+int bse_get_bcm_index(void) { return bse_last_bcm_index; }
+int bse_get_bpp_index(void) { return bse_last_bpp_index; }
+
 void bse_evolv2(int *kstar, double *mass0, double *mass, double *rad, double *lum,
 		double *massc, double *radc, double *menv, double *renv, double *ospin,
                 double *B_0, double *bacc, double *tacc,
@@ -139,20 +148,26 @@ void bse_evolv2(int *kstar, double *mass0, double *mass, double *rad, double *lu
         vs[i] = 0.0;
     }
 
-    double kick_info[17][2];
+    double kick_info[18][2];
 
 
-    for(i=0;i<17;i++) {
+    for(i=0;i<18;i++) {
         for(j=0;j<2;j++){
             kick_info[i][j] = 0.0;
         }
     }
 
-    /* used by COSMIC, but not needed here */
-    //double bppout[23][1000], bcmout[42][50000];
+    /* New evolv2 out args. Stack-local so each call gets a fresh buffer;
+     * cached into bse_last_*_index for handle_bse_outcome via getters. */
+    int bpp_index_out = 0;
+    int bcm_index_out = 0;
+    double kick_info_out[18][2];
+    for (i = 0; i < 18; i++) { kick_info_out[i][0] = 0.0; kick_info_out[i][1] = 0.0; }
 
-    evolv2_(kstar,mass,tb,ecc,z,tphysf,dtp,mass0,rad,lum,massc,radc, menv,renv,ospin,B_0,bacc,tacc,epoch,tms,bhspin,tphys,zpars,vs, *kick_info);
+    evolv2_(kstar,mass,tb,ecc,z,tphysf,dtp,mass0,rad,lum,massc,radc, menv,renv,ospin,B_0,bacc,tacc,epoch,tms,bhspin,tphys,zpars,vs, *kick_info, &bpp_index_out, &bcm_index_out, *kick_info_out);
 
+    bse_last_bcm_index = bcm_index_out;
+    bse_last_bpp_index = bpp_index_out;
 }
 
 /**
@@ -351,7 +366,10 @@ void bse_star(int *kw, double *mass, double *mt, double *tm, double *tn, double 
      GB = giant branch parameters (10)
    */
 
-  star_(kw, mass, mt, tm, tn, tscls, lums, GB, zpars);
+  /* dtm, id are METISSE-only; SSE path ignores them. */
+  double dtm = 0.0;
+  int id = 0;
+  star_(kw, mass, mt, tm, tn, tscls, lums, GB, zpars, &dtm, &id);
 }
 
 /* hrdiag routine; shouldn't need to be used often outside of BSE */
@@ -440,10 +458,10 @@ void bse_kick(int *kw, double *m1, double *m1n, double *m2, double *ecc, double 
    */
   /* LOGICAL used by COSMIC, but not needed here */
     int disrupt=0;
-    double kick_info[17][2];
+    double kick_info[18][2];
     int i, j ;
 
-    for(i=0;i<17;i++) {
+    for(i=0;i<18;i++) {
         for(j=0;j<2;j++){
             kick_info[i][j] = 0.0;
         }
@@ -463,7 +481,9 @@ void bse_kick(int *kw, double *m1, double *m1n, double *m2, double *ecc, double 
 */
 void bse_mix(double *mass, double *mt, double *aj, int *kw, double *zpars, double *bhspin)
 {
-  mix_(mass, mt, aj, kw, zpars, bhspin);
+  /* dtm is METISSE-only; SSE path ignores it. */
+  double dtm = 0.0;
+  mix_(mass, mt, aj, kw, zpars, bhspin, &dtm);
 }
 
 /**
@@ -489,9 +509,9 @@ void bse_comenv(bse_binary *tempbinary, double *zpars, double *vs, int *fb)
   int jp=0,switchedCE=0, disrupt=0;
   double tphys=0, evolve_type=0;
   double tms[2], rad[2], lumin[2], B_0[2], bacc[2], tacc[2], epoch[2], menv_bpp[2], renv_bpp[2];
-  double kick_info[17][2];
+  double kick_info[18][2];
 
-  for(i=0;i<17;i++) {
+  for(i=0;i<18;i++) {
       for(j=0;j<2;j++){
           kick_info[i][j] = 0.0;
       }
@@ -568,9 +588,11 @@ void bse_comenv(bse_binary *tempbinary, double *zpars, double *vs, int *fb)
   //  printf("%g ", zpars[iii]);
   //}
   //printf(" kw1i=%d kw2i=%d m1i=%g m2i=%g r1i=%g r2i=%g epoch1=%g epoch2=%g ", (*tempbinary).bse_kw[0], (*tempbinary).bse_kw[1], (*tempbinary).bse_mass[0], (*tempbinary).bse_mass[1], (*tempbinary).bse_radius[0], (*tempbinary).bse_radius[1], (*tempbinary).bse_epoch[0], (*tempbinary).bse_epoch[1]);
+  /* deltam_1, deltam_2, dtm are METISSE-only; SSE path ignores them. */
+  double comenv_deltam_1 = 0.0, comenv_deltam_2 = 0.0, comenv_dtm = 0.0;
   comenv_(&((*tempbinary).bse_mass0[0]), &((*tempbinary).bse_mass[0]), &((*tempbinary).bse_massc[0]), &(AJ[0]), &JSPIN1, &((*tempbinary).bse_kw[0]),
 	  &((*tempbinary).bse_mass0[1]), &((*tempbinary).bse_mass[1]), &((*tempbinary).bse_massc[1]), &(AJ[1]), &JSPIN2, &((*tempbinary).bse_kw[1]),
-	  zpars, &((*tempbinary).e), &((*tempbinary).a), &(JORB), &COEL, &star1, &star2, &vk, *kick_info, &((*tempbinary).bse_bcm_formation[0]), &((*tempbinary).bse_bcm_formation[1]), &snvars_.sigma, &((*tempbinary).bse_bhspin[0]),&((*tempbinary).bse_bhspin[1]),&binstate,&mergertype,&jp,&tphys,&switchedCE,rad,tms,&evolve_type,&disrupt,lumin,B_0,bacc,tacc,epoch,menv_bpp,renv_bpp,vs);
+	  zpars, &((*tempbinary).e), &((*tempbinary).a), &(JORB), &COEL, &star1, &star2, &vk, *kick_info, &((*tempbinary).bse_bcm_formation[0]), &((*tempbinary).bse_bcm_formation[1]), &snvars_.sigma, &((*tempbinary).bse_bhspin[0]),&((*tempbinary).bse_bhspin[1]),&binstate,&mergertype,&jp,&tphys,&switchedCE,rad,tms,&evolve_type,&disrupt,lumin,B_0,bacc,tacc,epoch,menv_bpp,renv_bpp,vs,&comenv_deltam_1,&comenv_deltam_2,&comenv_dtm);
   //printf("kw1i=%d kw2i=%d m1f=%g m2f=%g r1f=%g r2f=%g ", (*tempbinary).bse_kw[0], (*tempbinary).bse_kw[1], (*tempbinary).bse_mass[0], (*tempbinary).bse_mass[1], (*tempbinary).bse_radius[0], (*tempbinary).bse_radius[1]);
   //printf("\n");
   ////
@@ -661,7 +683,7 @@ void bse_set_htpmb(int htpmb) { flags_.htpmb = htpmb; }
 void bse_set_rejuvflag(int rejuvflag) { flags_.rejuvflag = rejuvflag; }
 void bse_set_qcflag(int qcflag) { flags_.qcflag = qcflag; }
 void bse_set_don_lim(double don_lim) { mtvars_.don_lim = don_lim; }
-void bse_set_acc_lim(double acc_lim) { mtvars_.acc_lim = acc_lim; }
+void bse_set_acc_lim(double acc_lim) { mtvars_.acc_lim[0] = acc_lim; mtvars_.acc_lim[1] = acc_lim; }
 void bse_set_ussn(int ussn) { ceflags_.ussn = ussn; }
 void bse_set_neta(double neta) { windvars_.neta = neta; }
 void bse_set_bwind(double bwind) { windvars_.bwind = bwind; }
@@ -689,7 +711,7 @@ void bse_set_rejuv_fac(double rejuv_fac) {mixvars_.rejuv_fac = rejuv_fac;}
 void bse_set_pts1(double pts1) { points_.pts1 = pts1; }
 void bse_set_pts2(double pts2) { points_.pts2 = pts2; }
 void bse_set_pts3(double pts3) { points_.pts3 = pts3; }
-void bse_set_alpha1(double alpha1) { cevars_.alpha1 = alpha1; }
+void bse_set_alpha1(double alpha1) { cevars_.alpha1[0] = alpha1; cevars_.alpha1[1] = alpha1; }
 void bse_set_lambdaf(double lambdaf) { cevars_.lambdaf = lambdaf; }
 void bse_set_ceflag(int ceflag) { ceflags_.ceflag = ceflag; }
 void bse_set_cemergeflag(int cemergeflag) { ceflags_.cemergeflag = cemergeflag; }
@@ -727,7 +749,7 @@ void bse_set_taus113state(struct rng_t113_state state, int first) {
 /* getters */
 /* note the index flip and decrement so the matrices are accessed
    as they would be in fortran */
-double bse_get_alpha1(void) { return(cevars_.alpha1); }
+double bse_get_alpha1(void) { return(cevars_.alpha1[0]); }
 double bse_get_lambdaf(void) { return(cevars_.lambdaf); }
 double bse_get_spp(int i, int j) { return(single_.spp[j-1][i-1]); }
 double bse_get_scm(int i, int j) { return(single_.scm[j-1][i-1]); }
@@ -763,9 +785,9 @@ void bse_set_bcm_bpp_cols(void){
         5,  7, 33, 34, 45, 46, 47, 48           /* sep..merger_type */
     };
 
-    int bcm_to_all_extra[11] = {
+    int bcm_to_all_extra[14] = {
        10, 11, 12, 13, 14, 35, 36, 37, 38, 41,
-       42
+       42, 49, 50, 51
     };
 
     for(i=0 ; i < BCM_NUM_COLUMNS ; i++)
@@ -773,7 +795,7 @@ void bse_set_bcm_bpp_cols(void){
             col_.col_inds_bcm[i] = bcm_to_all[i]+1;
         } else {
             col_.col_inds_bcm[i] = bcm_to_all_extra[i-38]+1;
-        }  
+        }
 
     for(i=0 ; i < BPP_NUM_COLUMNS ; i++)
         if (i<43) {

--- a/src/cmc/CMakeLists.txt
+++ b/src/cmc/CMakeLists.txt
@@ -18,6 +18,11 @@ include_directories(SYSTEM ${ZLIB_INCLUDE_DIRS})
 include_directories(SYSTEM ${HDF5_INCLUDE_DIRS})
 
 # MPI compile options
+# -Wl,--no-relax is GNU ld only; Apple ld rejects it. Needed on some HPC Linux builds
+# to avoid long-range branch errors when linking large Fortran objects.
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    SET( CMAKE_C_FLAGS "-Wl,--no-relax" )
+endif()
 target_compile_options(cmc PRIVATE ${MPI_COMPILE_FLAGS})
 
 # link library to executable

--- a/src/cmc/cmc_bse_utils.c
+++ b/src/cmc/cmc_bse_utils.c
@@ -259,7 +259,7 @@ void compress_binary(star_t *bincom, binary_t *bin) {
 * @param ecsn_mlow ?
 * @param ST_tide ?
 */
-void cmc_bse_comenv(binary_t *tempbinary, double cmc_l_unit, double RbloodySUN, double *zpars, double *kick_info, int *fb)
+void cmc_bse_comenv(binary_t *tempbinary, double cmc_l_unit, double RbloodySUN, double *zpars, double kick_info[19][2], int *fb)
 		//double *M0, double *M, double *MC, double *AJ, double *OSPIN, int *KW, 
 		//                double *M02, double *M2, double *MC2, double *AJ2, double *JSPIN2, int *KW2,
                 //double *ZPARS, double *ECC, double *SEP, double *PORB,  

--- a/src/cmc/cmc_bse_utils.c
+++ b/src/cmc/cmc_bse_utils.c
@@ -253,13 +253,13 @@ void compress_binary(star_t *bincom, binary_t *bin) {
 * @param cmc_l_unit ?
 * @param RbloodySUN ?
 * @param zpars ?
-* @param vs ?
+* @param kick_info ?
 * @param fb ?
 * @param ecsnp ?
 * @param ecsn_mlow ?
 * @param ST_tide ?
 */
-void cmc_bse_comenv(binary_t *tempbinary, double cmc_l_unit, double RbloodySUN, double *zpars, double *vs, int *fb)
+void cmc_bse_comenv(binary_t *tempbinary, double cmc_l_unit, double RbloodySUN, double *zpars, double *kick_info, int *fb)
 		//double *M0, double *M, double *MC, double *AJ, double *OSPIN, int *KW, 
 		//                double *M02, double *M2, double *MC2, double *AJ2, double *JSPIN2, int *KW2,
                 //double *ZPARS, double *ECC, double *SEP, double *PORB,  
@@ -363,7 +363,7 @@ void cmc_bse_comenv(binary_t *tempbinary, double cmc_l_unit, double RbloodySUN, 
   binary.bse_bcm_formation[0] = tempbinary->bse_bcm_formation[0];
   binary.bse_bcm_formation[1] = tempbinary->bse_bcm_formation[1];
   //
-  bse_comenv(&(binary), zpars, vs, fb);
+  bse_comenv(&(binary), zpars, kick_info, fb);
   //
   tempbinary->a = binary.a * RSUN/cmc_l_unit;
   tempbinary->bse_tb = binary.bse_tb;

--- a/src/cmc/cmc_dynamics_helper.c
+++ b/src/cmc/cmc_dynamics_helper.c
@@ -1663,7 +1663,7 @@ void binint_do(long k, long kp, double rperi, double w[4], double W, double rcm,
 	fb_obj_t threeobjs[3];
 	char string1[1024], string2[1024];
 	star_t tempstar, tempstar2;
-	double vs[20], VK0;
+	double kick_info[19][2], VK0;
 	double energy_from_outer=0.;
 
 	/* perform actions that are specific to the type of binary interaction */
@@ -1942,12 +1942,9 @@ void binint_do(long k, long kp, double rperi, double w[4], double W, double rcm,
 														  hier.obj[i]->a_500M[nmerged]*cmc_units.l*units.l / FB_CONST_AU ,hier.obj[i]->e_500M[nmerged]);
                             star[knew].se_k = 14;
                         } else{
-                            merge_two_stars(&(star[knew]), &tempstar, &(star[knew]), vs, curr_st);
-                                                    /* Owing to merger only useful vs's are v[1-3] */
-                            star[knew].vr += vs[3] * 1.0e5 / (units.l/units.t);
-
-                            vt_add_kick(&(star[knew].vt),vs[1],vs[2], curr_st);
-                            //star[knew].vt += sqrt(vs[1]*vs[1]+vs[2]*vs[2]) * 1.0e5 / (units.l/units.t);
+                            merge_two_stars(&(star[knew]), &tempstar, &(star[knew]), kick_info, curr_st);
+                            star[knew].vr += kick_info[8][0] * 1.0e5 / (units.l/units.t);
+                            vt_add_kick(&(star[knew].vt),kick_info[6][0],kick_info[7][0], curr_st);
                         }
 						nmerged++;
 					}
@@ -1955,9 +1952,9 @@ void binint_do(long k, long kp, double rperi, double w[4], double W, double rcm,
 					
 					//star[knew].id = star_get_id_new();
 
-					if(vs[1]!=0.0){
-						VK0 = sqrt(sqr(vs[1])+sqr(vs[2])+sqr(vs[3]));
-						dprintf("dynhelp_merge1: TT=%.18g vs[0]=%.18g vs[1]=%.18g vs[2]=%.18g vs[3]=%.18g vs[4]=%.18g vs[5]=%.18g vs[6]=%.18g VK0=%.18g star_id=%ld\n",TotalTime,vs[0],vs[1],vs[2],vs[3],vs[4],vs[5],vs[6],VK0,star[knew].id);
+					if(kick_info[6][0]!=0.0){
+						VK0 = sqrt(sqr(kick_info[6][0])+sqr(kick_info[7][0])+sqr(kick_info[8][0]));
+						dprintf("dynhelp_merge1: TT=%.18g kick_info[0][0]=%.18g kick_info[6][0]=%.18g kick_info[7][0]=%.18g kick_info[8][0]=%.18g VK0=%.18g star_id=%ld\n",TotalTime,kick_info[0][0],kick_info[6][0],kick_info[7][0],kcik_info[8][0],VK0,star[knew].id);
 					}
 					
 					/* log collision */
@@ -2040,17 +2037,17 @@ void binint_do(long k, long kp, double rperi, double w[4], double W, double rcm,
 														  hier.obj[i]->obj[0]->a_500M[nmerged]*cmc_units.l*units.l / FB_CONST_AU ,hier.obj[i]->obj[0]->e_500M[nmerged]);
                             tempstar.se_k = 14;
                         } else{
-                            merge_two_stars(&tempstar, &tempstar2, &tempstar, vs, curr_st);
+                            merge_two_stars(&tempstar, &tempstar2, &tempstar, kick_info, curr_st);
                             /* FIXME: really we're supposed to add the kick to each binary
                                member separately, then calculate the systemic kick to the binary,
                                but hopefully this doesn't happen too much. */
                                                     /* The kick routine within /bse_wrap/bse/ correctly updates COM velocity... */
-                            if (sqrt(vs[1]*vs[1]+vs[2]*vs[2]+vs[3]*vs[3]) != 0.0) {
+                            if (sqrt(kick_info[6][0]*kick_info[6][0]+kick_info[7][0]*kick_info[7][0]+kick_info[8][0]*kick_info[8][0]) != 0.0) {
                                 wprintf("Adding merger-induced kick of %g km/s to binary CoM instead of binary member!\n",
-                                    sqrt(vs[1]*vs[1]+vs[2]*vs[2]+vs[3]*vs[3]));
+                                    sqrt(kick_info[6][0]*kick_info[6][0]+kick_info[7][0]*kick_info[7][0]+kick_info[8][0]*kick_info[8][0]));
                             }
-                            star[knew].vr += vs[3] * 1.0e5 / (units.l/units.t);					       
-                            vt_add_kick(&(star[knew].vt),vs[1],vs[2], curr_st);
+                            star[knew].vr += kick_info[8][0] * 1.0e5 / (units.l/units.t);					       
+                            vt_add_kick(&(star[knew].vt),kick_info[6][0],kick_info[7][0], curr_st);
                         }
 						nmerged++;
 					}
@@ -2062,10 +2059,10 @@ void binint_do(long k, long kp, double rperi, double w[4], double W, double rcm,
 					//binary[star[knew].binind].id1 = star_get_id_new();
 					binary[star[knew].binind].id1 = tempstar.id;
 
-					if(vs[1]!=0.0){
-						VK0 = sqrt(sqr(vs[1])+sqr(vs[2])+sqr(vs[3]));
-						dprintf("dynhelp_merge2: TT=%.18g vs[0]=%.18g vs[1]=%.18g vs[2]=%.18g vs[3]=%.18g vs[4]=%.18g vs[5]=%.18g vs[6]=%.18g VK0=%.18g star_id=%ld\n",TotalTime,vs[0],vs[1],vs[2],vs[3],vs[4],vs[5],vs[6],VK0,binary[star[knew].binind].id1);
-					}
+                                        if(kick_info[6][0]!=0.0){
+                                                VK0 = sqrt(sqr(kick_info[6][0])+sqr(kick_info[7][0])+sqr(kick_info[8][0]));
+                                                dprintf("dynhelp_merge2: TT=%.18g kick_info[0][0]=%.18g kick_info[6][0]=%.18g kick_info[7][0]=%.18g kick_info[8][0]=%.18g VK0=%.18g star_id=%ld\n",TotalTime,kick_info[0][0],kick_info[6][0],kick_info[7][0],kick_info[8][0],VK0,binary[star[knew].binind].id1);
+                                        }
 					
 					/* log collision */
 					binint_log_collision(isbinbin?"binary-binary":"binary-single",
@@ -2129,16 +2126,16 @@ void binint_do(long k, long kp, double rperi, double w[4], double W, double rcm,
 														  hier.obj[i]->obj[1]->a_500M[nmerged]*cmc_units.l*units.l / FB_CONST_AU ,hier.obj[i]->obj[1]->e_500M[nmerged]);
                             tempstar.se_k = 14;
                         } else{
-                            merge_two_stars(&tempstar, &tempstar2, &tempstar, vs, curr_st);
+                            merge_two_stars(&tempstar, &tempstar2, &tempstar, kick_info, curr_st);
                             /* FIXME: really we're supposed to add the kick to each binary
                                member separately, then calculate the systemic kick to the binary,
                                but hopefully this doesn't happen too much. */
-                            if (sqrt(vs[1]*vs[1]+vs[2]*vs[2]+vs[3]*vs[3]) != 0.0) {
+                            if (sqrt(kick_info[6][0]*kick_info[6][0]+kick_info[7][0]*kick_info[7][0]+kick_info[8][0]*kick_info[8][0]) != 0.0) {
                                 wprintf("Adding merger-induced kick of %g km/s to binary CoM instead of binary member!\n",
-                                    sqrt(vs[1]*vs[1]+vs[2]*vs[2]+vs[3]*vs[3]));
+                                    sqrt(kick_info[6][0]*kick_info[6][0]+kick_info[7][0]*kick_info[7][0]+kick_info[8][0]*kick_info[8][0]));
                             }
-                            star[knew].vr += vs[3] * 1.0e5 / (units.l/units.t);					       
-                            vt_add_kick(&(star[knew].vt),vs[1],vs[2], curr_st);
+                            star[knew].vr += kick_info[8][0] * 1.0e5 / (units.l/units.t);					       
+                            vt_add_kick(&(star[knew].vt),kick_info[6][0],kick_info[7][0], curr_st);
                         }
 						nmerged++;
 					}
@@ -2150,10 +2147,10 @@ void binint_do(long k, long kp, double rperi, double w[4], double W, double rcm,
 					//binary[star[knew].binind].id2 = star_get_id_new();
 					binary[star[knew].binind].id2 = tempstar.id;
 
-					if(vs[1]!=0.0){
-						VK0 = sqrt(sqr(vs[1])+sqr(vs[2])+sqr(vs[3]));
-						dprintf("dynhelp_merge3: TT=%.18g vs[0]=%.18g vs[1]=%.18g vs[2]=%.18g vs[3]=%.18g vs[4]=%.18g vs[5]=%.18g vs[6]=%.18g VK0=%.18g star_id=%ld\n",TotalTime,vs[0],vs[1],vs[2],vs[3],vs[4],vs[5],vs[6],VK0,binary[star[knew].binind].id2);
-					}
+                                        if(kick_info[6][0]!=0.0){
+                                                VK0 = sqrt(sqr(kick_info[6][0])+sqr(kick_info[7][0])+sqr(kick_info[8][0]));
+                                                dprintf("dynhelp_merge3: TT=%.18g kick_info[0][0]=%.18g kick_info[6][0]=%.18g kick_info[7][0]=%.18g kick_info[8][0]=%.18g VK0=%.18g star_id=%ld\n",TotalTime,kick_info[0][0],kick_info[6][0],kick_info[7][0],kick_info[8][0],VK0,binary[star[knew].binind].id2);
+                                        }
 
 					/* log collision */
 					binint_log_collision(isbinbin?"binary-binary":"binary-single",
@@ -2271,21 +2268,21 @@ void binint_do(long k, long kp, double rperi, double w[4], double W, double rcm,
 														  hier.obj[i]->obj[sid]->a_500M[nmerged]*cmc_units.l*units.l / FB_CONST_AU ,hier.obj[i]->obj[sid]->e_500M[nmerged]);
                             star[knewp].se_k = 14;
                         } else{
-                            merge_two_stars(&(star[knewp]), &tempstar, &(star[knewp]), vs, curr_st);
-                            star[knewp].vr += vs[3] * 1.0e5 / (units.l/units.t);					       
+                            merge_two_stars(&(star[knewp]), &tempstar, &(star[knewp]), kick_info, curr_st);
+                            star[knewp].vr += kick_info[8][0] * 1.0e5 / (units.l/units.t);					       
 
                             //MPI2: parallel rng mimicking removed due to parent function which takes k as parameter?
-                            vt_add_kick(&(star[knewp].vt),vs[1],vs[2], curr_st);
+                            vt_add_kick(&(star[knewp].vt),kick_info[6][0],kick_info[7][0], curr_st);
                         }
 						nmerged++;
 					}
 					set_star_EJ(knewp);
 
 					//star[knewp].id = star_get_id_new();
-					if(vs[1]!=0.0){
-						VK0 = sqrt(sqr(vs[1])+sqr(vs[2])+sqr(vs[3]));
-						dprintf("dynhelp_merge4: TT=%.18g vs[0]=%.18g vs[1]=%.18g vs[2]=%.18g vs[3]=%.18g vs[4]=%.18g vs[5]=%.18g vs[6]=%.18g VK0=%.18g star_id=%ld\n",TotalTime,vs[0],vs[1],vs[2],vs[3],vs[4],vs[5],vs[6],VK0,star[knewp].id);
-					}
+					if(kick_info[6][0]!=0.0){
+                                                VK0 = sqrt(sqr(kick_info[6][0])+sqr(kick_info[7][0])+sqr(kick_info[8][0]));
+                                                dprintf("dynhelp_merge4: TT=%.18g kick_info[0][0]=%.18g kick_info[6][0]=%.18g kick_info[7][0]=%.18g kick_info[8][0]=%.18g VK0=%.18g star_id=%ld\n",TotalTime,kick_info[0][0],kick_info[6][0],kick_info[7][0],kick_info[8][0],VK0,star[knewp].id);
+                                        }
 					/* log collision */
                     star_m[get_global_idx(knewp)] = star[knewp].m;
 					binint_log_collision(isbinbin?"binary-binary":"binary-single",
@@ -2363,16 +2360,16 @@ void binint_do(long k, long kp, double rperi, double w[4], double W, double rcm,
 														  hier.obj[i]->obj[bid]->obj[0]->a_500M[nmerged]*cmc_units.l*units.l / FB_CONST_AU ,hier.obj[i]->obj[bid]->obj[0]->e_500M[nmerged]);
                             tempstar.se_k = 14;
                         } else{
-                            merge_two_stars(&tempstar, &tempstar2, &tempstar, vs, curr_st);
+                            merge_two_stars(&tempstar, &tempstar2, &tempstar, kick_info, curr_st);
                             /* FIXME: really we're supposed to add the kick to each binary
                                member separately, then calculate the systemic kick to the binary,
                                but hopefully this doesn't happen too much. */
-                            if (sqrt(vs[1]*vs[1]+vs[2]*vs[2]+vs[3]*vs[3]) != 0.0) {
+                            if (sqrt(kick_info[6][0]*kick_info[6][0]+kick_info[7][0]*kick_info[7][0]+kick_info[8][0]*kick_info[8][0]) != 0.0) {
                                 wprintf("Adding merger-induced kick of %g km/s to binary CoM instead of binary member!\n",
-                                    sqrt(vs[1]*vs[1]+vs[2]*vs[2]+vs[3]*vs[3]));
+                                    sqrt(kick_info[6][0]*kick_info[6][0]+kick_info[7][0]*kick_info[7][0]+kick_info[8][0]*kick_info[8][0]));
                             }
-                            star[knew].vr += vs[3] * 1.0e5 / (units.l/units.t);					       
-                            vt_add_kick(&(star[knew].vt),vs[1],vs[2], curr_st);
+                            star[knew].vr += kick_info[8][0] * 1.0e5 / (units.l/units.t);					       
+                            vt_add_kick(&(star[knew].vt),kick_info[6][0],kick_info[7][0], curr_st);
                         }
 						nmerged++;
 					}
@@ -2383,10 +2380,10 @@ void binint_do(long k, long kp, double rperi, double w[4], double W, double rcm,
 
 					binary[star[knew].binind].id1 = tempstar.id;
 					//binary[star[knew].binind].id1 = star_get_id_new();
-					if(vs[1]!=0.0){
-						VK0 = sqrt(sqr(vs[1])+sqr(vs[2])+sqr(vs[3]));
-						dprintf("dynhelp_merge5: TT=%.18g vs[0]=%.18g vs[1]=%.18g vs[2]=%.18g vs[3]=%.18g vs[4]=%.18g vs[5]=%.18g vs[6]=%.18g VK0=%.18g star_id=%ld\n",TotalTime,vs[0],vs[1],vs[2],vs[3],vs[4],vs[5],vs[6],VK0,binary[star[knew].binind].id1);
-					}
+					if(kick_info[6][0]!=0.0){
+                                                VK0 = sqrt(sqr(kick_info[6][0])+sqr(kick_info[7][0])+sqr(kick_info[8][0]));
+                                                dprintf("dynhelp_merge5: TT=%.18g kick_info[0][0]=%.18g kick_info[6][0]=%.18g kick_info[7][0]=%.18g kick_info[8][0]=%.18g VK0=%.18g star_id=%ld\n",TotalTime,kick_info[0][0],kick_info[6][0],kick_info[7][0],kick_info[8][0],VK0,binary[star[knew].binind].id1);
+                                        }
 					/* log collision */
 					
 					binint_log_collision(isbinbin?"binary-binary":"binary-single",
@@ -2447,16 +2444,16 @@ void binint_do(long k, long kp, double rperi, double w[4], double W, double rcm,
 														  hier.obj[i]->obj[bid]->obj[1]->a_500M[nmerged]*cmc_units.l*units.l / FB_CONST_AU ,hier.obj[i]->obj[bid]->obj[1]->e_500M[nmerged]);
                             tempstar.se_k = 14;
                         } else{
-                            merge_two_stars(&tempstar, &tempstar2, &tempstar, vs, curr_st);
+                            merge_two_stars(&tempstar, &tempstar2, &tempstar, kick_info, curr_st);
                             /* FIXME: really we're supposed to add the kick to each binary
                                member separately, then calculate the systemic kick to the binary,
                                but hopefully this doesn't happen too much. */
-                            if (sqrt(vs[1]*vs[1]+vs[2]*vs[2]+vs[3]*vs[3]) != 0.0) {
+                            if (sqrt(kick_info[6][0]*kick_info[6][0]+kick_info[7][0]*kick_info[7][0]+kick_info[8][0]*kick_info[8][0]) != 0.0) {
                                 wprintf("Adding merger-induced kick of %g km/s to binary CoM instead of binary member!\n",
-                                    sqrt(vs[1]*vs[1]+vs[2]*vs[2]+vs[3]*vs[3]));
+                                    sqrt(kick_info[6][0]*kick_info[6][0]+kick_info[7][0]*kick_info[7][0]+kick_info[8][0]*kick_info[8][0]));
                             }
-                            star[knew].vr += vs[3] * 1.0e5 / (units.l/units.t);					       
-                            vt_add_kick(&(star[knew].vt),vs[1],vs[2], curr_st);
+                            star[knew].vr += kick_info[8][0] * 1.0e5 / (units.l/units.t);					       
+                            vt_add_kick(&(star[knew].vt),kick_info[6][0],kick_info[7][0], curr_st);
                         }
 						nmerged++;
 					}

--- a/src/cmc/cmc_dynamics_helper.c
+++ b/src/cmc/cmc_dynamics_helper.c
@@ -1954,7 +1954,7 @@ void binint_do(long k, long kp, double rperi, double w[4], double W, double rcm,
 
 					if(kick_info[6][0]!=0.0){
 						VK0 = sqrt(sqr(kick_info[6][0])+sqr(kick_info[7][0])+sqr(kick_info[8][0]));
-						dprintf("dynhelp_merge1: TT=%.18g kick_info[0][0]=%.18g kick_info[6][0]=%.18g kick_info[7][0]=%.18g kick_info[8][0]=%.18g VK0=%.18g star_id=%ld\n",TotalTime,kick_info[0][0],kick_info[6][0],kick_info[7][0],kcik_info[8][0],VK0,star[knew].id);
+						dprintf("dynhelp_merge1: TT=%.18g kick_info[0][0]=%.18g kick_info[6][0]=%.18g kick_info[7][0]=%.18g kick_info[8][0]=%.18g VK0=%.18g star_id=%ld\n",TotalTime,kick_info[0][0],kick_info[6][0],kick_info[7][0],kick_info[8][0],VK0,star[knew].id);
 					}
 					
 					/* log collision */

--- a/src/cmc/cmc_io.c
+++ b/src/cmc/cmc_io.c
@@ -2569,7 +2569,7 @@ MPI: In the parallel version, IO is done in the following way. Some files requir
 
 		// print header
 		if (WRITE_BH_INFO)
-			pararootfprintf(newbhfile,"#1:time #2:r #3.binary? #4:ID #5:zams_m #6:m_progenitor #7:bh mass #8:bh_spin #9:birth-kick(km/s) #10-28:vsarray\n");
+			pararootfprintf(newbhfile,"#1:time #2:r #3.binary? #4:ID #5:zams_m #6:m_progenitor #7:bh mass #8:bh_spin #9:birth-kick(km/s) #10-28:kick_info array\n");
 			pararootfprintf(bhmergerfile,"#1:time #2:type #3.r #4:id1 #5:id2 #6:m1[MSUN] #7:m2[MSUN] #8:spin1 #9:spin2 #10:final_id #11:m_final[MSUN] #12:spin_final #13:vkick[km/s] #14:v_esc[km/s] #15:a_final[AU] #16:e_final #17:a_50M[AU] #18:e_50 #19:a_100M[AU] #20:e_100M #21:a_500M[AU] #22:e_500M\n");
 			pararootfprintf(bhmergerfile,"#NOTE: if repeated mergers occur in fewbody (binary-single or binary-binary), the initial masses will be wrong; check collision.log\n");
 	//"#1:tcount  #2:TotalTime  #3:bh  #4:bh_single  #5:bh_binary  #6:bh-bh  #7:bh-ns  #8:bh-wd  #9:bh-star  #10:bh-nonbh  #11:fb_bh  #12:bh_tot  #13:bh_single_tot  #14:bh_binary_tot  #15:bh-bh_tot  #16:bh-ns_tot  #17:bh-wd_tot  #18:bh-star_tot  #19:bh-nonbh_tot  #20:fb_bh_tot\n");
@@ -2580,7 +2580,7 @@ MPI: In the parallel version, IO is done in the following way. Some files requir
                 /* print header */ //CSY
                 if (WRITE_MOREPULSAR_INFO) {
                		pararootfprintf(morepulsarfile,"#1:tcount #2:TotalTime #3:binflag #4:id0 #5:id1 #6:m0[MSUN] #7:m1[MSUN] #8:B0[G] #9:B1[G] #10:P0[sec] #11:P1[sec] #12:startype0 #13:startype1 #14:a[AU] #15:ecc #16:radrol0 #17:radrol1 #18:dmdt0 #19:dmdt1 #20:r #21:vr #22:vt #23:bacc0 #24:bacc1 #25:tacc0 #26:tacc1 #27:formation0 #28:formation1\n");
-                        pararootfprintf(newnsfile,"#1:time #2:r #3.binary? #4:ID #5:zams_m #6:m_progenitor #7:ns_mass #8:ns_formation #9:birth-kick(km/s) #10:kprev\n");
+                        pararootfprintf(newnsfile,"#1:time #2:r #3.binary? #4:ID #5:zams_m #6:m_progenitor #7:ns_mass #8:ns_formation #9:birth-kick(km/s) #10:kprev #11-29:kick_info array\n");
                 }
                 /* print header */ //Elena
                 if (WRITE_MORECOLL_INFO)

--- a/src/cmc/cmc_io.c
+++ b/src/cmc/cmc_io.c
@@ -1164,6 +1164,43 @@ if(myid==0) {
 				PRINT_PARSED(PARAMDOC_STELLAR_EVOLUTION);
 				sscanf(values, "%ld", &STELLAR_EVOLUTION);
 				parsed.STELLAR_EVOLUTION = 1;
+			} else if (strcmp(parameter_name, "STELLAR_ENGINE") == 0) {
+				PRINT_PARSED(PARAMDOC_STELLAR_ENGINE);
+				if (strncmp(values, "sse", 3) == 0) {
+					STELLAR_ENGINE = 0;
+				} else if (strncmp(values, "metisse", 7) == 0) {
+					STELLAR_ENGINE = 1;
+				} else {
+					eprintf("ERROR: STELLAR_ENGINE must be 'sse' or 'metisse' (got '%s').\n", values);
+					exit_cleanly(-1, __FUNCTION__);
+				}
+				parsed.STELLAR_ENGINE = 1;
+			} else if (strcmp(parameter_name, "PATH_TO_TRACKS") == 0) {
+				PRINT_PARSED(PARAMDOC_PATH_TO_TRACKS);
+				if (strncmp(values, "None", 4) == 0) {
+					PATH_TO_TRACKS = NULL;
+				} else {
+					PATH_TO_TRACKS = (char *) malloc(sizeof(char) * 256);
+					strncpy(PATH_TO_TRACKS, values, 256);
+				}
+				parsed.PATH_TO_TRACKS = 1;
+			} else if (strcmp(parameter_name, "PATH_TO_HE_TRACKS") == 0) {
+				PRINT_PARSED(PARAMDOC_PATH_TO_HE_TRACKS);
+				if (strncmp(values, "None", 4) == 0) {
+					PATH_TO_HE_TRACKS = NULL;
+				} else {
+					PATH_TO_HE_TRACKS = (char *) malloc(sizeof(char) * 256);
+					strncpy(PATH_TO_HE_TRACKS, values, 256);
+				}
+				parsed.PATH_TO_HE_TRACKS = 1;
+			} else if (strcmp(parameter_name, "Z_MATCH_LIMIT") == 0) {
+				PRINT_PARSED(PARAMDOC_Z_MATCH_LIMIT);
+				sscanf(values, "%lf", &Z_MATCH_LIMIT);
+				parsed.Z_MATCH_LIMIT = 1;
+			} else if (strcmp(parameter_name, "METISSE_VERBOSE") == 0) {
+				PRINT_PARSED(PARAMDOC_METISSE_VERBOSE);
+				sscanf(values, "%ld", &METISSE_VERBOSE);
+				parsed.METISSE_VERBOSE = 1;
 			} else if (strcmp(parameter_name, "TIDAL_TREATMENT") == 0) {
 				PRINT_PARSED(PARAMDOC_TIDAL_TREATMENT);
 				sscanf(values, "%ld", &TIDAL_TREATMENT);
@@ -1670,6 +1707,11 @@ if(myid==0) {
 	CHECK_PARSED(TIDALLY_STRIP_STARS, 1, PARAMDOC_TIDALLY_STRIP_STARS);
 	CHECK_PARSED(THETASEMAX, 1.412, PARAMDOC_THETASEMAX);
 	CHECK_PARSED(STELLAR_EVOLUTION, 0, PARAMDOC_STELLAR_EVOLUTION);
+	CHECK_PARSED(STELLAR_ENGINE, 0, PARAMDOC_STELLAR_ENGINE);
+	CHECK_PARSED(PATH_TO_TRACKS, NULL, PARAMDOC_PATH_TO_TRACKS);
+	CHECK_PARSED(PATH_TO_HE_TRACKS, NULL, PARAMDOC_PATH_TO_HE_TRACKS);
+	CHECK_PARSED(Z_MATCH_LIMIT, 1.0e-2, PARAMDOC_Z_MATCH_LIMIT);
+	CHECK_PARSED(METISSE_VERBOSE, 0, PARAMDOC_METISSE_VERBOSE);
     CHECK_PARSED(WRITE_STELLAR_INFO, 0, PARAMDOC_WRITE_STELLAR_INFO);
     CHECK_PARSED(WRITE_BH_INFO, 0, PARAMDOC_WRITE_BH_INFO);
     CHECK_PARSED(WRITE_RWALK_INFO, 0, PARAMDOC_WRITE_RWALK_INFO);

--- a/src/cmc/cmc_io.c
+++ b/src/cmc/cmc_io.c
@@ -2569,7 +2569,7 @@ MPI: In the parallel version, IO is done in the following way. Some files requir
 
 		// print header
 		if (WRITE_BH_INFO)
-			pararootfprintf(newbhfile,"#1:time #2:r #3.binary? #4:ID #5:zams_m #6:m_progenitor #7:bh mass #8:bh_spin #9:birth-kick(km/s) #10-25:vsarray\n");
+			pararootfprintf(newbhfile,"#1:time #2:r #3.binary? #4:ID #5:zams_m #6:m_progenitor #7:bh mass #8:bh_spin #9:birth-kick(km/s) #10-28:vsarray\n");
 			pararootfprintf(bhmergerfile,"#1:time #2:type #3.r #4:id1 #5:id2 #6:m1[MSUN] #7:m2[MSUN] #8:spin1 #9:spin2 #10:final_id #11:m_final[MSUN] #12:spin_final #13:vkick[km/s] #14:v_esc[km/s] #15:a_final[AU] #16:e_final #17:a_50M[AU] #18:e_50 #19:a_100M[AU] #20:e_100M #21:a_500M[AU] #22:e_500M\n");
 			pararootfprintf(bhmergerfile,"#NOTE: if repeated mergers occur in fewbody (binary-single or binary-binary), the initial masses will be wrong; check collision.log\n");
 	//"#1:tcount  #2:TotalTime  #3:bh  #4:bh_single  #5:bh_binary  #6:bh-bh  #7:bh-ns  #8:bh-wd  #9:bh-star  #10:bh-nonbh  #11:fb_bh  #12:bh_tot  #13:bh_single_tot  #14:bh_binary_tot  #15:bh-bh_tot  #16:bh-ns_tot  #17:bh-wd_tot  #18:bh-star_tot  #19:bh-nonbh_tot  #20:fb_bh_tot\n");

--- a/src/cmc/cmc_sscollision.c
+++ b/src/cmc/cmc_sscollision.c
@@ -1109,7 +1109,7 @@ void sscollision_do(long k, long kp, double rperimax, double w[4], double W, dou
 * @param kick_info ?
 * @param s rng state
 */
-void merge_two_stars(star_t *star1, star_t *star2, star_t *merged_star, double *kick_info, struct rng_t113_state* s) {
+void merge_two_stars(star_t *star1, star_t *star2, star_t *merged_star, double kick_info[19][2], struct rng_t113_state* s) {
 	double tphysf, dtp, age, temp_rad, bseaj[2];
 	//double vsaddl[12], 
 	double tm, tn, tscls[20], lums[10], GB[10], k2, lamb_val;

--- a/src/cmc/cmc_sscollision.c
+++ b/src/cmc/cmc_sscollision.c
@@ -24,7 +24,7 @@ void sscollision_do(long k, long kp, double rperimax, double w[4], double W, dou
 {
 	//int ST_tide; //PDK addition for hrdiag, will eventually make it an input from cmc_stelar_evolution.c
 	long knew;
-	double vs[20], bmax, b, rperi, Eorbnew, acoll, ecoll, ace, ece, anew, enew, efinal, afinal;
+	double kick_info[19][2], bmax, b, rperi, Eorbnew, acoll, ecoll, ace, ece, anew, enew, efinal, afinal;
 	double clight5;
 	double aj, aj_k, aj_kp, tm, tn, tscls[20], lums[10], GB[10], k2;
 	double Einit;
@@ -225,16 +225,15 @@ void sscollision_do(long k, long kp, double rperimax, double w[4], double W, dou
                         //MPI: Since we pass the star pointer itself into the merging routine, we need to copy the duplicated array values back into the star element before passing it in.
                         copy_globals_to_locals(k);
                         copy_globals_to_locals(kp);
-                        merge_two_stars(&(star[k]), &(star[kp]), &(star[knew]), vs, curr_st);
+                        merge_two_stars(&(star[k]), &(star[kp]), &(star[knew]), kick_info, curr_st);
                                 
                         g_knew = get_global_idx(knew);
                         star_r[g_knew] = rcm;
                         star_m[g_knew] = star[knew].m;
                         star[knew].vr = vcm[3];
                         star[knew].vt = sqrt(sqr(vcm[1])+sqr(vcm[2]));
-                        star[knew].vr += vs[3] * 1.0e5 / (units.l/units.t);
-                        vt_add_kick(&(star[knew].vt),vs[1],vs[2], curr_st);
-                        //star[knew].vt += sqrt(vs[1]*vs[1]+vs[2]*vs[2]) * 1.0e5 / (units.l/units.t);
+                        star[knew].vr += kick_info[8][0] * 1.0e5 / (units.l/units.t);
+                        vt_add_kick(&(star[knew].vt), kick_info[6][0], kick_info[7][0], curr_st);
                                 
                         star_phi[g_knew] = potential(star_r[g_knew]);
                         set_star_EJ(knew);
@@ -431,16 +430,15 @@ void sscollision_do(long k, long kp, double rperimax, double w[4], double W, dou
                         //MPI: Since we pass the star pointer itself into the merging routine, we need to copy the duplicated array values back into the star element before passing it in.
                         copy_globals_to_locals(k);
                         copy_globals_to_locals(kp);
-                        merge_two_stars(&(star[k]), &(star[kp]), &(star[knew]), vs, curr_st);
+                        merge_two_stars(&(star[k]), &(star[kp]), &(star[knew]), kick_info, curr_st);
 
                         g_knew = get_global_idx(knew);
                         star_r[g_knew] = rcm;
                         star_m[g_knew] = star[knew].m;
                         star[knew].vr = vcm[3];
                         star[knew].vt = sqrt(sqr(vcm[1])+sqr(vcm[2]));
-                        star[knew].vr += vs[3] * 1.0e5 / (units.l/units.t);
-                        vt_add_kick(&(star[knew].vt),vs[1],vs[2], curr_st);
-                        //star[knew].vt += sqrt(vs[1]*vs[1]+vs[2]*vs[2]) * 1.0e5 / (units.l/units.t);
+                        star[knew].vr += kick_info[8][0] * 1.0e5 / (units.l/units.t);
+                        vt_add_kick(&(star[knew].vt), kick_info[6][0], kick_info[7][0], curr_st);
 
                         star_phi[g_knew] = potential(star_r[g_knew]);
                         set_star_EJ(knew);
@@ -612,16 +610,15 @@ void sscollision_do(long k, long kp, double rperimax, double w[4], double W, dou
 
                         copy_globals_to_locals(k);
                         copy_globals_to_locals(kp);
-                        merge_two_stars(&(star[k]), &(star[kp]), &(star[knew]), vs, curr_st);
+                        merge_two_stars(&(star[k]), &(star[kp]), &(star[knew]), kick_info, curr_st);
 
                         g_knew = get_global_idx(knew);
                         star_r[g_knew] = rcm;
                         star_m[g_knew] = star[knew].m;
                         star[knew].vr = vcm[3];
                         star[knew].vt = sqrt(sqr(vcm[1])+sqr(vcm[2]));
-                        star[knew].vr += vs[3] * 1.0e5 / (units.l/units.t);
-                        vt_add_kick(&(star[knew].vt),vs[1],vs[2], curr_st);
-                        //star[knew].vt += sqrt(vs[1]*vs[1]+vs[2]*vs[2]) * 1.0e5 / (units.l/units.t);
+                        star[knew].vr += kick_info[8][0] * 1.0e5 / (units.l/units.t);
+                        vt_add_kick(&(star[knew].vt), kick_info[6][0], kick_info[7][0], curr_st);
 
                         star_phi[g_knew] = potential(star_r[g_knew]);
                         set_star_EJ(knew);
@@ -836,16 +833,15 @@ void sscollision_do(long k, long kp, double rperimax, double w[4], double W, dou
         //MPI: Since we pass the star pointer itself into the merging routine, we need to copy the duplicated array values back into the star element before passing it in.
         copy_globals_to_locals(k);
         copy_globals_to_locals(kp);
-                merge_two_stars(&(star[k]), &(star[kp]), &(star[knew]), vs, curr_st);
+                merge_two_stars(&(star[k]), &(star[kp]), &(star[knew]), kick_info, curr_st);
 
                 g_knew = get_global_idx(knew);
                 star_r[g_knew] = rcm;
                 star_m[g_knew] = star[knew].m;
                 star[knew].vr = vcm[3];
                 star[knew].vt = sqrt(sqr(vcm[1])+sqr(vcm[2]));
-                star[knew].vr += vs[3] * 1.0e5 / (units.l/units.t);
-                vt_add_kick(&(star[knew].vt),vs[1],vs[2], curr_st);
-                //star[knew].vt += sqrt(vs[1]*vs[1]+vs[2]*vs[2]) * 1.0e5 / (units.l/units.t);
+                star[knew].vr += kick_info[8][0] * 1.0e5 / (units.l/units.t);
+                vt_add_kick(&(star[knew].vt), kick_info[6][0], kick_info[7][0], curr_st);
                 
                 star_phi[g_knew] = potential(star_r[g_knew]);
                 set_star_EJ(knew);
@@ -964,16 +960,15 @@ void sscollision_do(long k, long kp, double rperimax, double w[4], double W, dou
                         //MPI: Since we pass the star pointer itself into the merging routine, we need to copy the duplicated array values back into the star element before passing it in.
                          copy_globals_to_locals(k);
                          copy_globals_to_locals(kp);
-                                merge_two_stars(&(star[k]), &(star[kp]), &(star[knew]), vs, curr_st);
+                                merge_two_stars(&(star[k]), &(star[kp]), &(star[knew]), kick_info, curr_st);
   
                                 g_knew = get_global_idx(knew);
                                 star_r[g_knew] = rcm;
                                 star_m[g_knew] = star[knew].m;
                                 star[knew].vr = vcm[3];
                                 star[knew].vt = sqrt(sqr(vcm[1])+sqr(vcm[2]));
-                                star[knew].vr += vs[3] * 1.0e5 / (units.l/units.t);
-                                vt_add_kick(&(star[knew].vt),vs[1],vs[2], curr_st);
-                                //star[knew].vt += sqrt(vs[1]*vs[1]+vs[2]*vs[2]) * 1.0e5 / (units.l/units.t);         
+                                star[knew].vr += kick_info[8][0] * 1.0e5 / (units.l/units.t);
+                                vt_add_kick(&(star[knew].vt), kick_info[6][0], kick_info[7][0], curr_st);         
         
                                 star_phi[g_knew] = potential(star_r[g_knew]);
                                 set_star_EJ(knew);
@@ -1111,10 +1106,10 @@ void sscollision_do(long k, long kp, double rperimax, double w[4], double W, dou
 * @param star1 pointer to star 1
 * @param star2 pointer to star 2
 * @param merged_star pointer to merged star
-* @param vs ?
+* @param kick_info ?
 * @param s rng state
 */
-void merge_two_stars(star_t *star1, star_t *star2, star_t *merged_star, double *vs, struct rng_t113_state* s) {
+void merge_two_stars(star_t *star1, star_t *star2, star_t *merged_star, double *kick_info, struct rng_t113_state* s) {
 	double tphysf, dtp, age, temp_rad, bseaj[2];
 	//double vsaddl[12], 
 	double tm, tn, tscls[20], lums[10], GB[10], k2, lamb_val;
@@ -1123,9 +1118,11 @@ void merge_two_stars(star_t *star1, star_t *star2, star_t *merged_star, double *
         double TDE_arr[2];
 	fb = 1;
 
-	for(i=0;i<20;i++) {
-	  vs[i] = 0.0;
-	}
+        for(i=0;i<19;i++) {
+            for(j=0;j<2;j++){
+                kick_info[i][j] = 0.0;
+            }
+        }
 
   bse_set_taus113state(*curr_st, 0);
 
@@ -1294,7 +1291,7 @@ void merge_two_stars(star_t *star1, star_t *star2, star_t *merged_star, double *
 		      }
 		      //CALL comenv routine...
 		      cmc_bse_comenv(&(tempbinary), units.l, RSUN, zpars, 
-				     vs, &fb);
+				     kick_info, &fb);
 		      dprintf("after ce merge1: tb=%g a=%g m1=%g m2=%g e=%g kw1=%d kw2=%d r1=%g r2=%g\n",tempbinary.bse_tb,tempbinary.a,tempbinary.bse_mass[0],tempbinary.bse_mass[1],tempbinary.e,tempbinary.bse_kw[0],tempbinary.bse_kw[1],tempbinary.bse_radius[0],tempbinary.bse_radius[1]);
 		      ktry++;
 		    }
@@ -1519,10 +1516,10 @@ void merge_two_stars(star_t *star1, star_t *star2, star_t *merged_star, double *
 				      &(tempbinary.bse_ospin[0]), &(tempbinary.bse_B_0[0]), &(tempbinary.bse_bacc[0]), &(tempbinary.bse_tacc[0]),
 				      &(tempbinary.bse_epoch[0]), &(tempbinary.bse_tms[0]), 
 				      &(tempbinary.bse_tphys), &tphysf, &dtp, &METALLICITY, zpars, 
-				      &(tempbinary.bse_tb), &(tempbinary.e), vs, &(tempbinary.bse_bhspin[0]));
+				      &(tempbinary.bse_tb), &(tempbinary.e), kick_info, &(tempbinary.bse_bhspin[0]));
 		    fprintf(stderr, "a ns is born? cmc_sscollision.c\n"); 
 		    fprintf(stderr, "RftR: tphys=%g tphysf=%g kstar1=%d kstar2=%d m1=%g m2=%g r1=%g r2=%g l1=%g l2=%g tb=%g\n", tempbinary.bse_tphys, tphysf, tempbinary.bse_kw[0], tempbinary.bse_kw[1], tempbinary.bse_mass[0], tempbinary.bse_mass[1], tempbinary.bse_radius[0], tempbinary.bse_radius[1], tempbinary.bse_lum[0], tempbinary.bse_lum[1], tempbinary.bse_tb);
-		    fprintf(stderr, "vk_y=%g should be>0...\n", vs[2]);
+		    fprintf(stderr, "vk_y=%g should be>0...\n", kick_info[7][0]);
 		  } else if (icase <= 100 && (tempbinary.bse_kw[0]==14 || tempbinary.bse_kw[1]==14)){
 		    bse_set_merger(BSE_SIGMA);
 		    fprintf(stderr, "BH merge=265.0\n");
@@ -1539,9 +1536,9 @@ void merge_two_stars(star_t *star1, star_t *star2, star_t *merged_star, double *
 				      &(tempbinary.bse_ospin[0]), &(tempbinary.bse_B_0[0]), &(tempbinary.bse_bacc[0]), &(tempbinary.bse_tacc[0]), 
 				      &(tempbinary.bse_epoch[0]), &(tempbinary.bse_tms[0]), 
 				      &(tempbinary.bse_tphys), &tphysf, &dtp, &METALLICITY, zpars, 
-				      &(tempbinary.bse_tb), &(tempbinary.e), vs, &(tempbinary.bse_bhspin[0]));
+				      &(tempbinary.bse_tb), &(tempbinary.e), kick_info, &(tempbinary.bse_bhspin[0]));
 		    fprintf(stderr, "RftR: tphys=%g tphysf=%g kstar1=%d kstar2=%d m1=%g m2=%g r1=%g r2=%g l1=%g l2=%g tb=%g bhspin1=%g bhspin2=%g\n", tempbinary.bse_tphys, tphysf, tempbinary.bse_kw[0], tempbinary.bse_kw[1], tempbinary.bse_mass[0], tempbinary.bse_mass[1], tempbinary.bse_radius[0], tempbinary.bse_radius[1], tempbinary.bse_lum[0], tempbinary.bse_lum[1], tempbinary.bse_tb,tempbinary.bse_bhspin[0],tempbinary.bse_bhspin[1]);
-		    fprintf(stderr, "BH vk_y=%g should be>0...\n", vs[2]);
+		    fprintf(stderr, "BH vk_y=%g should be>0...\n", kick_info[7][0]);
 		  }
                   
                   // CSY: Add NS-MS TDE compact object mass change and spin up of NS
@@ -1575,7 +1572,7 @@ void merge_two_stars(star_t *star1, star_t *star2, star_t *merged_star, double *
                                     &(tempbinary.bse_ospin[0]), &(tempbinary.bse_B_0[0]), &(tempbinary.bse_bacc[0]), &(tempbinary.bse_tacc[0]),
                                     &(tempbinary.bse_epoch[0]), &(tempbinary.bse_tms[0]),
                                     &(tempbinary.bse_tphys), &tphysf, &dtp, &METALLICITY, zpars,
-                                    &(tempbinary.bse_tb), &(tempbinary.e), vs, &(tempbinary.bse_bhspin[0]));
+                                    &(tempbinary.bse_tb), &(tempbinary.e), kick_info, &(tempbinary.bse_bhspin[0]));
                   }
 
 		  bse_set_merger(-1.0);
@@ -1699,9 +1696,11 @@ void merge_two_stars(star_t *star1, star_t *star2, star_t *merged_star, double *
 	    vs[1] = 0.0;
 	    vs[2] = 0.0; */
 	  /* */
-	        for (i=0; i<=11; i++) {
-	                vs[i] = 0.0;
-                }		
+                for(i=0;i<19;i++) {
+                    for(j=0;j<2;j++){
+                        kick_info[i][j] = 0.0;
+                    }
+                } 
 		if (STAR_AGING_SCHEME==1){
 			merged_star->lifetime = pow(10.0,9.921)*pow(merged_star->m*units.mstar/MSUN,-3.6648)*YEAR*log(GAMMA*clus.N_STAR)/units.t/clus.N_STAR;
 			age = (merged_star->lifetime/merged_star->m)*
@@ -1729,8 +1728,10 @@ void merge_two_stars(star_t *star1, star_t *star2, star_t *merged_star, double *
 /*		vs[0] = 0.0;
 		vs[1] = 0.0;
 		vs[2] = 0.0; */
-                for (i=0; i<=11; i++) {
-                   vs[i] = 0.0;
+                for(i=0;i<19;i++) {
+                    for(j=0;j<2;j++){
+                        kick_info[i][j] = 0.0;
+                    } 
                 }
 	}
   *curr_st= bse_get_taus113state();

--- a/src/cmc/cmc_sscollision.c
+++ b/src/cmc/cmc_sscollision.c
@@ -232,8 +232,15 @@ void sscollision_do(long k, long kp, double rperimax, double w[4], double W, dou
                         star_m[g_knew] = star[knew].m;
                         star[knew].vr = vcm[3];
                         star[knew].vt = sqrt(sqr(vcm[1])+sqr(vcm[2]));
-                        star[knew].vr += kick_info[8][0] * 1.0e5 / (units.l/units.t);
-                        vt_add_kick(&(star[knew].vt), kick_info[6][0], kick_info[7][0], curr_st);
+                        
+                        for (int sn = 0; sn < 2; sn++) {
+                            if (kick_info[0][sn] > 0.0) {
+                                star[knew].vr += kick_info[8][sn] * 1.0e5 / (units.l/units.t);
+                                vt_add_kick(&(star[knew].vt), kick_info[6][sn], kick_info[7][sn], curr_st);
+                            }
+                        }
+                        //star[knew].vr += kick_info[8][0] * 1.0e5 / (units.l/units.t);
+                        //vt_add_kick(&(star[knew].vt), kick_info[6][0], kick_info[7][0], curr_st);
                                 
                         star_phi[g_knew] = potential(star_r[g_knew]);
                         set_star_EJ(knew);
@@ -437,8 +444,14 @@ void sscollision_do(long k, long kp, double rperimax, double w[4], double W, dou
                         star_m[g_knew] = star[knew].m;
                         star[knew].vr = vcm[3];
                         star[knew].vt = sqrt(sqr(vcm[1])+sqr(vcm[2]));
-                        star[knew].vr += kick_info[8][0] * 1.0e5 / (units.l/units.t);
-                        vt_add_kick(&(star[knew].vt), kick_info[6][0], kick_info[7][0], curr_st);
+                        for (int sn = 0; sn < 2; sn++) {
+                            if (kick_info[0][sn] > 0.0) {
+                                star[knew].vr += kick_info[8][sn] * 1.0e5 / (units.l/units.t);
+                                vt_add_kick(&(star[knew].vt), kick_info[6][sn], kick_info[7][sn], curr_st);
+                            }
+                        }
+                        //star[knew].vr += kick_info[8][0] * 1.0e5 / (units.l/units.t);
+                        //vt_add_kick(&(star[knew].vt), kick_info[6][0], kick_info[7][0], curr_st);
 
                         star_phi[g_knew] = potential(star_r[g_knew]);
                         set_star_EJ(knew);
@@ -617,8 +630,14 @@ void sscollision_do(long k, long kp, double rperimax, double w[4], double W, dou
                         star_m[g_knew] = star[knew].m;
                         star[knew].vr = vcm[3];
                         star[knew].vt = sqrt(sqr(vcm[1])+sqr(vcm[2]));
-                        star[knew].vr += kick_info[8][0] * 1.0e5 / (units.l/units.t);
-                        vt_add_kick(&(star[knew].vt), kick_info[6][0], kick_info[7][0], curr_st);
+                        for (int sn = 0; sn < 2; sn++) {
+                            if (kick_info[0][sn] > 0.0) {
+                                star[knew].vr += kick_info[8][sn] * 1.0e5 / (units.l/units.t);
+                                vt_add_kick(&(star[knew].vt), kick_info[6][sn], kick_info[7][sn], curr_st);
+                            }
+                        }
+                        //star[knew].vr += kick_info[8][0] * 1.0e5 / (units.l/units.t);
+                        //vt_add_kick(&(star[knew].vt), kick_info[6][0], kick_info[7][0], curr_st);
 
                         star_phi[g_knew] = potential(star_r[g_knew]);
                         set_star_EJ(knew);
@@ -840,8 +859,14 @@ void sscollision_do(long k, long kp, double rperimax, double w[4], double W, dou
                 star_m[g_knew] = star[knew].m;
                 star[knew].vr = vcm[3];
                 star[knew].vt = sqrt(sqr(vcm[1])+sqr(vcm[2]));
-                star[knew].vr += kick_info[8][0] * 1.0e5 / (units.l/units.t);
-                vt_add_kick(&(star[knew].vt), kick_info[6][0], kick_info[7][0], curr_st);
+                for (int sn = 0; sn < 2; sn++) {
+                    if (kick_info[0][sn] > 0.0) {
+                        star[knew].vr += kick_info[8][sn] * 1.0e5 / (units.l/units.t);
+                        vt_add_kick(&(star[knew].vt), kick_info[6][sn], kick_info[7][sn], curr_st);
+                    }
+                } 
+                //star[knew].vr += kick_info[8][0] * 1.0e5 / (units.l/units.t);
+                //vt_add_kick(&(star[knew].vt), kick_info[6][0], kick_info[7][0], curr_st);
                 
                 star_phi[g_knew] = potential(star_r[g_knew]);
                 set_star_EJ(knew);
@@ -967,8 +992,14 @@ void sscollision_do(long k, long kp, double rperimax, double w[4], double W, dou
                                 star_m[g_knew] = star[knew].m;
                                 star[knew].vr = vcm[3];
                                 star[knew].vt = sqrt(sqr(vcm[1])+sqr(vcm[2]));
-                                star[knew].vr += kick_info[8][0] * 1.0e5 / (units.l/units.t);
-                                vt_add_kick(&(star[knew].vt), kick_info[6][0], kick_info[7][0], curr_st);         
+                                for (int sn = 0; sn < 2; sn++) {
+                                    if (kick_info[0][sn] > 0.0) {
+                                        star[knew].vr += kick_info[8][sn] * 1.0e5 / (units.l/units.t);
+                                        vt_add_kick(&(star[knew].vt), kick_info[6][sn], kick_info[7][sn], curr_st);
+                                    }
+                                }
+                                //star[knew].vr += kick_info[8][0] * 1.0e5 / (units.l/units.t);
+                                //vt_add_kick(&(star[knew].vt), kick_info[6][0], kick_info[7][0], curr_st);         
         
                                 star_phi[g_knew] = potential(star_r[g_knew]);
                                 set_star_EJ(knew);
@@ -1510,6 +1541,7 @@ void merge_two_stars(star_t *star1, star_t *star2, star_t *merged_star, double k
 // if msp set merger value to something other than -1.0 then it will trigger possibly a setting of NS particulars, a reset of NS particulars to msp-like values (-2.0), else reset to 'standard' birth properties or magnatar(see Maxim V. Barkov &Serguei S. Komissarov 2011?). Plus, of course we give the NSs kicks etc.
 		    fprintf(stderr, "a ns is born? cmc_sscollision.c\n"); 
 		    fprintf(stderr, "B4: tphys=%g tphysf=%g kstar1=%d kstar2=%d m1=%g m2=%g r1=%g r2=%g l1=%g l2=%g tb=%g\n", tempbinary.bse_tphys, tphysf, tempbinary.bse_kw[0], tempbinary.bse_kw[1], tempbinary.bse_mass[0], tempbinary.bse_mass[1], tempbinary.bse_radius[0], tempbinary.bse_radius[1], tempbinary.bse_lum[0], tempbinary.bse_lum[1], tempbinary.bse_tb);
+
 		    bse_evolv2_safely(&(tempbinary.bse_kw[0]), &(tempbinary.bse_mass0[0]), &(tempbinary.bse_mass[0]), 
 				      &(tempbinary.bse_radius[0]), &(tempbinary.bse_lum[0]), &(tempbinary.bse_massc[0]), 
 				      &(tempbinary.bse_radc[0]), &(tempbinary.bse_menv[0]), &(tempbinary.bse_renv[0]), 
@@ -1517,6 +1549,8 @@ void merge_two_stars(star_t *star1, star_t *star2, star_t *merged_star, double k
 				      &(tempbinary.bse_epoch[0]), &(tempbinary.bse_tms[0]), 
 				      &(tempbinary.bse_tphys), &tphysf, &dtp, &METALLICITY, zpars, 
 				      &(tempbinary.bse_tb), &(tempbinary.e), kick_info, &(tempbinary.bse_bhspin[0]));
+
+
 		    fprintf(stderr, "a ns is born? cmc_sscollision.c\n"); 
 		    fprintf(stderr, "RftR: tphys=%g tphysf=%g kstar1=%d kstar2=%d m1=%g m2=%g r1=%g r2=%g l1=%g l2=%g tb=%g\n", tempbinary.bse_tphys, tphysf, tempbinary.bse_kw[0], tempbinary.bse_kw[1], tempbinary.bse_mass[0], tempbinary.bse_mass[1], tempbinary.bse_radius[0], tempbinary.bse_radius[1], tempbinary.bse_lum[0], tempbinary.bse_lum[1], tempbinary.bse_tb);
 		    fprintf(stderr, "vk_y=%g should be>0...\n", kick_info[7][0]);
@@ -1530,6 +1564,8 @@ void merge_two_stars(star_t *star1, star_t *star2, star_t *merged_star, double k
 		    tempbinary.bse_tb = 0.0;
 		    dtp = 0.0;
 		    fprintf(stderr, "B4: tphys=%g tphysf=%g kstar1=%d kstar2=%d m1=%g m2=%g r1=%g r2=%g l1=%g l2=%g tb=%g bhspin1=%g bhspin2=%g\n", tempbinary.bse_tphys, tphysf, tempbinary.bse_kw[0], tempbinary.bse_kw[1], tempbinary.bse_mass[0], tempbinary.bse_mass[1], tempbinary.bse_radius[0], tempbinary.bse_radius[1], tempbinary.bse_lum[0], tempbinary.bse_lum[1], tempbinary.bse_tb, tempbinary.bse_bhspin[0],tempbinary.bse_bhspin[1]);
+
+
 		    bse_evolv2_safely(&(tempbinary.bse_kw[0]), &(tempbinary.bse_mass0[0]), &(tempbinary.bse_mass[0]), 
 				      &(tempbinary.bse_radius[0]), &(tempbinary.bse_lum[0]), &(tempbinary.bse_massc[0]), 
 				      &(tempbinary.bse_radc[0]), &(tempbinary.bse_menv[0]), &(tempbinary.bse_renv[0]), 
@@ -1537,6 +1573,8 @@ void merge_two_stars(star_t *star1, star_t *star2, star_t *merged_star, double k
 				      &(tempbinary.bse_epoch[0]), &(tempbinary.bse_tms[0]), 
 				      &(tempbinary.bse_tphys), &tphysf, &dtp, &METALLICITY, zpars, 
 				      &(tempbinary.bse_tb), &(tempbinary.e), kick_info, &(tempbinary.bse_bhspin[0]));
+
+
 		    fprintf(stderr, "RftR: tphys=%g tphysf=%g kstar1=%d kstar2=%d m1=%g m2=%g r1=%g r2=%g l1=%g l2=%g tb=%g bhspin1=%g bhspin2=%g\n", tempbinary.bse_tphys, tphysf, tempbinary.bse_kw[0], tempbinary.bse_kw[1], tempbinary.bse_mass[0], tempbinary.bse_mass[1], tempbinary.bse_radius[0], tempbinary.bse_radius[1], tempbinary.bse_lum[0], tempbinary.bse_lum[1], tempbinary.bse_tb,tempbinary.bse_bhspin[0],tempbinary.bse_bhspin[1]);
 		    fprintf(stderr, "BH vk_y=%g should be>0...\n", kick_info[7][0]);
 		  }
@@ -1566,6 +1604,8 @@ void merge_two_stars(star_t *star1, star_t *star2, star_t *merged_star, double k
                         }
                         bse_set_merger(-2.0);
                         dtp=0.0; //not sure if I need this
+
+                    
                         bse_evolv2_safely(&(tempbinary.bse_kw[0]), &(tempbinary.bse_mass0[0]), &(tempbinary.bse_mass[0]),
                                     &(tempbinary.bse_radius[0]), &(tempbinary.bse_lum[0]), &(tempbinary.bse_massc[0]),
                                     &(tempbinary.bse_radc[0]), &(tempbinary.bse_menv[0]), &(tempbinary.bse_renv[0]),
@@ -1573,6 +1613,8 @@ void merge_two_stars(star_t *star1, star_t *star2, star_t *merged_star, double k
                                     &(tempbinary.bse_epoch[0]), &(tempbinary.bse_tms[0]),
                                     &(tempbinary.bse_tphys), &tphysf, &dtp, &METALLICITY, zpars,
                                     &(tempbinary.bse_tb), &(tempbinary.e), kick_info, &(tempbinary.bse_bhspin[0]));
+
+
                   }
 
 		  bse_set_merger(-1.0);

--- a/src/cmc/cmc_stellar_evolution.c
+++ b/src/cmc/cmc_stellar_evolution.c
@@ -322,11 +322,12 @@ void stellar_evolution_init(void){
       DMse -= star_m[g_k] * madhoc;
       /* birth kicks */
       if (kick_info[2][0] != 0.0) {
-        //dprintf("birth kick of %f km/s\n", kick_info[2][0]);
+        fprintf(stderr, "DEBUG 0: birth kick of %f km/s\n", kick_info[2][0]);
+        fflush(stderr);
       }
       star[k].vr += kick_info[8][0] * 1.0e5 / (units.l/units.t);
 
-      vt_add_kick(&(star[k].vt),kick_info[7][0],kick_info[6][0], curr_st);
+      vt_add_kick(&(star[k].vt),kick_info[6][0],kick_info[7][0], curr_st);
       set_star_EJ(k);
     } else if (star[k].binind > 0) { /* binary */
       star[k].se_k = NOT_A_STAR; /* just for safety */
@@ -363,6 +364,8 @@ void stellar_evolution_init(void){
       bse_set_id1_pass(binary[kb].id1);
       bse_set_id2_pass(binary[kb].id2);
       bse_set_taus113state(*curr_st, 0);
+      
+     
       bse_evolv2(&(binary[kb].bse_kw[0]), &(binary[kb].bse_mass0[0]), &(binary[kb].bse_mass[0]), &(binary[kb].bse_radius[0]), 
               &(binary[kb].bse_lum[0]), &(binary[kb].bse_massc[0]), &(binary[kb].bse_radc[0]), &(binary[kb].bse_menv[0]), 
               &(binary[kb].bse_renv[0]), &(binary[kb].bse_ospin[0]), 
@@ -372,7 +375,18 @@ void stellar_evolution_init(void){
               &(binary[kb].bse_tb), &(binary[kb].e), kick_info, &(binary[kb].bse_bhspin[0]));
       *curr_st=bse_get_taus113state();
 
+      if (binary[kb].bse_mass[0]>20. || binary[kb].bse_mass[1]>20.){
+          fprintf(stderr, "DEBUG 0 (binary): About to extract supernova kick physics from the array.\n");
+          fflush(stderr);
+      }
+
       handle_bse_outcome(k, kb, kick_info, tphysf, kprev0, kprev1, &VKO);
+
+      if (binary[kb].bse_mass[0]>20. || binary[kb].bse_mass[1]>20.){
+          fprintf(stderr, "DEBUG 0 (binary): Successfully processed kick physics without crashing.\n");
+          fflush(stderr);
+      }
+
     } else {
       eprintf("totally confused!\n");
       exit_cleanly(-1, __FUNCTION__);
@@ -412,6 +426,16 @@ void do_stellar_evolution(gsl_rng *rng)
 
   //MPI: The serial version runs till N_MAX_NEW+1 to account for the sentinel. But in the parallel version, there is no sentinel, so runs only till N_MAX_NEW.
   for(k=1; k<=clus.N_MAX_NEW; k++){ 
+    if (k == 7762) {
+        if (star[k].binind == 0) {
+            fprintf(stderr, "\n>>> Starting Star %ld (SINGLE) | Type: %d | Mass: %g\n", k, star[k].se_k, star[k].se_mt);
+        } else {
+            kb = star[k].binind;
+            fprintf(stderr, "\n>>> Starting Star %ld (BINARY) | Types: %d/%d | Masses: %g/%g\n", k, binary[kb].bse_kw[0], binary[kb].bse_kw[1], binary[kb].bse_mass[0], binary[kb].bse_mass[1]);
+        }
+        fflush(stderr);
+    }  
+
     int g_k = get_global_idx(k);
     if (star[k].binind == 0) { /* single star */
       tphysf = TotalTime / MEGA_YEAR;
@@ -477,6 +501,7 @@ void do_stellar_evolution(gsl_rng *rng)
           &(star[k].se_tphys), &tphysf, &dtp, &METALLICITY, zpars, vs);
          */
         bse_set_taus113state(*curr_st, 0);
+
         bse_evolv2_safely(&(tempbinary.bse_kw[0]), &(tempbinary.bse_mass0[0]), &(tempbinary.bse_mass[0]), 
             &(tempbinary.bse_radius[0]), &(tempbinary.bse_lum[0]), &(tempbinary.bse_massc[0]), 
             &(tempbinary.bse_radc[0]), &(tempbinary.bse_menv[0]), &(tempbinary.bse_renv[0]), 
@@ -484,6 +509,7 @@ void do_stellar_evolution(gsl_rng *rng)
             &(tempbinary.bse_epoch[0]), &(tempbinary.bse_tms[0]), 
             &(star[k].se_tphys), &tphysf, &dtp, &METALLICITY, zpars, 
             &(tempbinary.bse_tb), &(tempbinary.e), kick_info, &(tempbinary.bse_bhspin[0]));
+
         *curr_st=bse_get_taus113state();
 
         star[k].se_mass = tempbinary.bse_mass0[0];
@@ -503,6 +529,7 @@ void do_stellar_evolution(gsl_rng *rng)
         star[k].se_tms = tempbinary.bse_tms[0];
 	star[k].se_bhspin = tempbinary.bse_bhspin[0];
 
+
 		  /*Reset the MS timestep once we're done*/
 		  if(reduced_timestep == 1)
 			  bse_set_pts1(BSE_PTS1);
@@ -510,7 +537,7 @@ void do_stellar_evolution(gsl_rng *rng)
         star[k].rad = star[k].se_radius * RSUN / units.l;
         star_m[g_k] = star[k].se_mt * MSUN / units.mstar;
         DMse -= star_m[g_k] * madhoc;
-
+        
         /* extract info from scm array */ /* PK looping over a large number anticipating further changes */
 	        i = 1;
 	        j = 1;
@@ -556,14 +583,17 @@ void do_stellar_evolution(gsl_rng *rng)
           //           exit_cleanly(-1); //should only enter here if no bcm array entry, 
           //                               and that should only happen to uninteresting systems and/or outcomes.
         	}
+        
 
         /* birth kicks */
         if (kick_info[2][0] != 0.0) {
-          //dprintf("birth kick of %f km/s\n", kick_info[2][0]);
+          fprintf(stderr, "DEBUG 4: birth kick of %f km/s\n", kick_info[2][0]);
+          fflush(stderr);
         }
         star[k].vr += kick_info[8][0] * 1.0e5 / (units.l/units.t);
 
         vt_add_kick(&(star[k].vt),kick_info[6][0],kick_info[7][0], curr_st);
+        
         set_star_EJ(k);
         VKO = sqrt(kick_info[6][0]*kick_info[6][0] + kick_info[7][0]*kick_info[7][0] + kick_info[8][0]*kick_info[8][0]);
         /* birth kicks */
@@ -580,7 +610,7 @@ void do_stellar_evolution(gsl_rng *rng)
         /*  star[k].vt += sin(theta) * vk; */
         /*  set_star_EJ(k); */
         /* } */
-		
+        
 	/* PDK search for boom stuff and write pulsar data. */
 		//bcm_boom_search(k, vs, getCMCvalues);
 		if(WRITE_PULSAR_INFO)
@@ -661,6 +691,7 @@ void do_stellar_evolution(gsl_rng *rng)
                         }
 		} else{
 			bse_set_taus113state(*curr_st, 0);
+                        
 			bse_evolv2_safely(&(binary[kb].bse_kw[0]), &(binary[kb].bse_mass0[0]), &(binary[kb].bse_mass[0]), &(binary[kb].bse_radius[0]), 
 				&(binary[kb].bse_lum[0]), &(binary[kb].bse_massc[0]), &(binary[kb].bse_radc[0]), &(binary[kb].bse_menv[0]), 
 					&(binary[kb].bse_renv[0]), &(binary[kb].bse_ospin[0]),
@@ -668,6 +699,8 @@ void do_stellar_evolution(gsl_rng *rng)
 				&(binary[kb].bse_epoch[0]), &(binary[kb].bse_tms[0]), 
 				&(binary[kb].bse_tphys), &tphysf, &dtp, &METALLICITY, zpars, 
 				&(binary[kb].bse_tb), &(binary[kb].e), kick_info, &(binary[kb].bse_bhspin[0]));
+                        
+                        
 			*curr_st=bse_get_taus113state();
 		}
 
@@ -694,7 +727,7 @@ void do_stellar_evolution(gsl_rng *rng)
   /*EGP: Note that when we delete objects, we zero out some quantities like the IDs, but a lot of bse params are not, hence why only the IDs were affected. */
   long prev_id1 = binary[kb].id1;
   long prev_id2 = binary[kb].id2;
-
+       
 	handle_bse_outcome(k, kb, kick_info, tphysf, kprev0, kprev1, &VKO);
 
 	if (WRITE_BH_INFO) {
@@ -728,9 +761,13 @@ void do_stellar_evolution(gsl_rng *rng)
 	//handle_bse_outcome(k, kb, vs, tphysf, kprev0, kprev1);
       }
     }
+    
+    
     bh_count(k);
+    
   }
 
+  
   double tmpTimeStart = timeStartSimple();
   double temp = 0.0;
 
@@ -1024,9 +1061,9 @@ void handle_bse_outcome(long k, long kb, double kick_info[19][2], double tphysf,
             }        
             
             // Legacy Disrupted Math: Only track Star 1's columns (6-8) as a sum of squares
-            vko_sq += sqrt(kick_info[6][sn]*kick_info[6][sn] + 
-                           kick_info[7][sn]*kick_info[7][sn] + 
-                           kick_info[8][sn]*kick_info[8][sn]); 
+            vko_sq += (kick_info[6][sn]*kick_info[6][sn] + 
+                       kick_info[7][sn]*kick_info[7][sn] + 
+                       kick_info[8][sn]*kick_info[8][sn]); 
             
         }
     }

--- a/src/cmc/cmc_stellar_evolution.c
+++ b/src/cmc/cmc_stellar_evolution.c
@@ -115,7 +115,7 @@ void restart_stellar_evolution(void){
 * of the parameters for individual stars
 */
 void stellar_evolution_init(void){  
-  double tphysf, dtp, vs[20];
+  double tphysf, dtp, kick_info[19][2];
   int i;
   long k, kb;
   int kprev0=-100;
@@ -297,7 +297,7 @@ void stellar_evolution_init(void){
           &(tempbinary.bse_ospin[0]), &(tempbinary.bse_B_0[0]), &(tempbinary.bse_bacc[0]), &(tempbinary.bse_tacc[0]),
           &(tempbinary.bse_epoch[0]), &(tempbinary.bse_tms[0]), 
           &(star[k].se_tphys), &tphysf, &dtp, &METALLICITY, zpars, 
-          &(tempbinary.bse_tb), &(tempbinary.e), vs,&(tempbinary.bse_bhspin[0]));
+          &(tempbinary.bse_tb), &(tempbinary.e), kick_info, &(tempbinary.bse_bhspin[0]));
       *curr_st=bse_get_taus113state();
 
       star[k].se_mass = tempbinary.bse_mass0[0];
@@ -321,14 +321,12 @@ void stellar_evolution_init(void){
       star_m[g_k] = star[k].se_mt * MSUN / units.mstar;
       DMse -= star_m[g_k] * madhoc;
       /* birth kicks */
-      if (sqrt(vs[1]*vs[1]+vs[2]*vs[2]+vs[2]*vs[2]) != 0.0) {
-        //dprintf("birth kick of %f km/s\n", sqrt(vs[0]*vs[0]+vs[1]*vs[1]+vs[2]*vs[2]));
+      if (kick_info[2][0] != 0.0) {
+        //dprintf("birth kick of %f km/s\n", kick_info[2][0]);
       }
-      star[k].vr += vs[3] * 1.0e5 / (units.l/units.t);
+      star[k].vr += kick_info[8][0] * 1.0e5 / (units.l/units.t);
 
-
-      vt_add_kick(&(star[k].vt),vs[1],vs[2], curr_st);
-      //star[k].vt += sqrt(vs[1]*vs[1]+vs[2]*vs[2]) * 1.0e5 / (units.l/units.t);
+      vt_add_kick(&(star[k].vt),kick_info[7][0],kick_info[6][0], curr_st);
       set_star_EJ(k);
     } else if (star[k].binind > 0) { /* binary */
       star[k].se_k = NOT_A_STAR; /* just for safety */
@@ -371,10 +369,10 @@ void stellar_evolution_init(void){
               &(binary[kb].bse_B_0[0]), &(binary[kb].bse_bacc[0]), &(binary[kb].bse_tacc[0]),
               &(binary[kb].bse_epoch[0]), &(binary[kb].bse_tms[0]), 
               &(binary[kb].bse_tphys), &tphysf, &dtp, &METALLICITY, zpars, 
-              &(binary[kb].bse_tb), &(binary[kb].e), vs,&(binary[kb].bse_bhspin[0]));
+              &(binary[kb].bse_tb), &(binary[kb].e), kick_info, &(binary[kb].bse_bhspin[0]));
       *curr_st=bse_get_taus113state();
 
-      handle_bse_outcome(k, kb, vs, tphysf, kprev0, kprev1, &VKO);
+      handle_bse_outcome(k, kb, kick_info, tphysf, kprev0, kprev1, &VKO);
     } else {
       eprintf("totally confused!\n");
       exit_cleanly(-1, __FUNCTION__);
@@ -400,7 +398,7 @@ void do_stellar_evolution(gsl_rng *rng)
   long k, kb, j, jj;
   int kprev,i, ii;
   int kprev0, kprev1;
-  double dtp, tphysf, vs[20], VKO;
+  double dtp, tphysf, kick_info[19][2], VKO;
   double M_beforeSE, M10_beforeSE, M100_beforeSE, M1000_beforeSE, Mcore_beforeSE;
   double M_afterSE, M10_afterSE, M100_afterSE, M1000_afterSE, Mcore_afterSE;
   double r10_beforeSE, r100_beforeSE, r1000_beforeSE, rcore_beforeSE;
@@ -485,7 +483,7 @@ void do_stellar_evolution(gsl_rng *rng)
             &(tempbinary.bse_ospin[0]), &(tempbinary.bse_B_0[0]), &(tempbinary.bse_bacc[0]), &(tempbinary.bse_tacc[0]), 
             &(tempbinary.bse_epoch[0]), &(tempbinary.bse_tms[0]), 
             &(star[k].se_tphys), &tphysf, &dtp, &METALLICITY, zpars, 
-            &(tempbinary.bse_tb), &(tempbinary.e), vs, &(tempbinary.bse_bhspin[0]));
+            &(tempbinary.bse_tb), &(tempbinary.e), kick_info, &(tempbinary.bse_bhspin[0]));
         *curr_st=bse_get_taus113state();
 
         star[k].se_mass = tempbinary.bse_mass0[0];
@@ -560,20 +558,18 @@ void do_stellar_evolution(gsl_rng *rng)
         	}
 
         /* birth kicks */
-        if (sqrt(vs[1]*vs[1]+vs[2]*vs[2]+vs[3]*vs[3]) != 0.0) {
-          //dprintf("birth kick of %f km/s\n", sqrt(vs[0]*vs[0]+vs[1]*vs[1]+vs[2]*vs[2]));
+        if (kick_info[2][0] != 0.0) {
+          //dprintf("birth kick of %f km/s\n", kick_info[2][0]);
         }
-        star[k].vr += vs[3] * 1.0e5 / (units.l/units.t);
+        star[k].vr += kick_info[8][0] * 1.0e5 / (units.l/units.t);
 
-
-        vt_add_kick(&(star[k].vt),vs[1],vs[2], curr_st);
-        //star[k].vt += sqrt(vs[1]*vs[1]+vs[2]*vs[2]) * 1.0e5 / (units.l/units.t);
+        vt_add_kick(&(star[k].vt),kick_info[6][0],kick_info[7][0], curr_st);
         set_star_EJ(k);
-        VKO = sqrt(vs[1]*vs[1]+vs[2]*vs[2]+vs[3]*vs[3]);
+        VKO = sqrt(kick_info[6][0]*kick_info[6][0] + kick_info[7][0]*kick_info[7][0] + kick_info[8][0]*kick_info[8][0]);
         /* birth kicks */
-        if (sqrt(vs[1]*vs[1]+vs[2]*vs[2]+vs[3]*vs[3]) != 0.0) {
-          //   dprintf("birth kick of %f km/s\n", sqrt(vs[0]*vs[0]+vs[1]*vs[1]+vs[2]*vs[2]));
-          dprintf("birth kick(iso): TT=%.18g, vs[0]=%.18g, vs[1]=%.18g, vs[2]=%.18g, vs[3]=%.18g, vr=%.18g, vt=%.18g VKO=%.18g type=%d star_id=%ld Pi=%g\n",TotalTime,vs[0],vs[1],vs[2],vs[3],star[k].vr,star[k].vt,VKO,star[k].se_k, star[k].id,star[k].se_ospin);
+        if (kick_info[2][0] != 0.0) {
+          //   dprintf("birth kick of %f km/s\n", kick_info[2][0]);
+          dprintf("birth kick(iso): TT=%.18g, kick_info[0][0]=%.18g, kick_info[6][0]=%.18g, kick_info[7][0]=%.18g, kick_info[8][0]=%.18g, vr=%.18g, vt=%.18g VKO=%.18g type=%d star_id=%ld Pi=%g\n",TotalTime,kick_info[0][0],kick_info[6][0],kick_info[7][0],kick_info[8][0],star[k].vr,star[k].vt,VKO,star[k].se_k, star[k].id,star[k].se_ospin);
         }
 
         /* WD birth kicks, just in case they exist */
@@ -609,8 +605,8 @@ void do_stellar_evolution(gsl_rng *rng)
 		if (WRITE_BH_INFO) {
 			if (kprev!=14 && star[k].se_k==14) { // newly formed BH
 				parafprintf(newbhfile, "%.18g %g 0 %ld %g %g %g %g %g", TotalTime, star_r[g_k], star[k].id,star[k].se_zams_mass,star[k].se_mass, star[k].se_mt, star[k].se_bhspin, VKO);
-				for (ii=0; ii<16; ii++){
-					parafprintf (newbhfile, " %g", vs[ii]);
+				for (ii=0; ii<19; ii++){
+					parafprintf (newbhfile, " %g", kick_info[ii][0]);
 				}
 				parafprintf (newbhfile, "\n");
 //m_init, m_bh, time, id, kick, r, vr_init, vt_init, vr_final, vt_final, binflag, m0_init, m1_init, m0_final, m1_final, 
@@ -658,7 +654,11 @@ void do_stellar_evolution(gsl_rng *rng)
 		 * Peters equations*/
 		if(binary[kb].bse_kw[0] == 14 && binary[kb].bse_kw[1] == 14){
 			integrate_a_e_peters_eqn(kb);
-			for (ii = 0 ; ii < 16 ; ii++) vs[ii] = 0.;
+                        for(ii=0;ii<19;ii++) {
+                            for(jj=0;jj<2;jj++){
+                                kick_info[ii][jj] = 0.0;
+                            }
+                        }
 		} else{
 			bse_set_taus113state(*curr_st, 0);
 			bse_evolv2_safely(&(binary[kb].bse_kw[0]), &(binary[kb].bse_mass0[0]), &(binary[kb].bse_mass[0]), &(binary[kb].bse_radius[0]), 
@@ -667,7 +667,7 @@ void do_stellar_evolution(gsl_rng *rng)
 						&(binary[kb].bse_B_0[0]), &(binary[kb].bse_bacc[0]), &(binary[kb].bse_tacc[0]),
 				&(binary[kb].bse_epoch[0]), &(binary[kb].bse_tms[0]), 
 				&(binary[kb].bse_tphys), &tphysf, &dtp, &METALLICITY, zpars, 
-				&(binary[kb].bse_tb), &(binary[kb].e), vs, &(binary[kb].bse_bhspin[0]));
+				&(binary[kb].bse_tb), &(binary[kb].e), kick_info, &(binary[kb].bse_bhspin[0]));
 			*curr_st=bse_get_taus113state();
 		}
 
@@ -695,20 +695,20 @@ void do_stellar_evolution(gsl_rng *rng)
   long prev_id1 = binary[kb].id1;
   long prev_id2 = binary[kb].id2;
 
-	handle_bse_outcome(k, kb, vs, tphysf, kprev0, kprev1, &VKO);
+	handle_bse_outcome(k, kb, kick_info, tphysf, kprev0, kprev1, &VKO);
 
 	if (WRITE_BH_INFO) {
 		if (kprev0!=14 && binary[kb].bse_kw[0]==14) { // newly formed BH
 			parafprintf(newbhfile, "%.18g %g 1 %ld %g %g %g %g %g", TotalTime, star_r[g_k], prev_id1, binary[kb].bse_zams_mass[0], binary[kb].bse_mass0[0], binary[kb].bse_mass[0], binary[kb].bse_bhspin[0], VKO);
-			for (ii=0; ii<16; ii++){
-				parafprintf (newbhfile, " %g", vs[ii]);
+			for (ii=0; ii<19; ii++){
+				parafprintf (newbhfile, " %g", kick_info[ii][0]);
 			}
 			parafprintf (newbhfile, "\n");
 		}
 		if (kprev1!=14 && binary[kb].bse_kw[1]==14 && binary[kb].id2 != 0) { // newly formed BH
 			parafprintf(newbhfile, "%.18g %g 1 %ld %g %g %g %g %g", TotalTime, star_r[g_k], prev_id2, binary[kb].bse_zams_mass[1],binary[kb].bse_mass0[1], binary[kb].bse_mass[1], binary[kb].bse_bhspin[1],VKO);
-			for (ii=0; ii<16; ii++){
-				parafprintf (newbhfile, " %g", vs[ii]);
+			for (ii=0; ii<19; ii++){
+				parafprintf (newbhfile, " %g", kick_info[ii][1]);
 			}
 			parafprintf (newbhfile, "\n");
 		}
@@ -837,10 +837,10 @@ void write_stellar_data(void){
 *
 * @param k index of star 1
 * @param kb index of star 2
-* @param vs ?
+* @param kick_info ?
 * @param tphysf ?
 */
-void handle_bse_outcome(long k, long kb, double *vs, double tphysf, int kprev0, int kprev1, double *VKO)
+void handle_bse_outcome(long k, long kb, double *kick_info, double tphysf, int kprev0, int kprev1, double *VKO)
 {
   int j, jj;
   long knew=0, knewp=0, convert;
@@ -937,34 +937,31 @@ void handle_bse_outcome(long k, long kb, double *vs, double tphysf, int kprev0, 
     DMse -= star_m[g_k] * madhoc;
     binary[kb].a = pow((binary[kb].bse_mass[0]+binary[kb].bse_mass[1])*sqr(binary[kb].bse_tb/365.25), 1.0/3.0)
       * AU / units.l;
-    if (sqrt(vs[1]*vs[1]+vs[2]*vs[2]+vs[3]*vs[3]) != 0.0) {
-      //dprintf("birth kick of %f km/s\n", sqrt(vs[0]*vs[0]+vs[1]*vs[1]+vs[2]*vs[2]));
+    if (kick_info[2][0] != 0.0 || kick_info[2][1] != 0.0) {
+      //dprintf("birth kick of %f and %f km/s\n", kick_info[2][0], kick_info[2][1]);
     }
-    if (vs[0] <= 0.0) {
-        star[k].vr += 0.0;
-        star[k].vt += 0.0;
-        set_star_EJ(k);
-        *VKO = 0.0;
-    } else if (vs[4] <= 0.0) {
-    /* If one kick */
-       star[k].vr += vs[3] * 1.0e5 / (units.l/units.t);
-       vt_add_kick(&(star[k].vt),vs[1],vs[2], curr_st);
-       //star[k].vt += sqrt(vs[1]*vs[1]+vs[2]*vs[2]) * 1.0e5 / (units.l/units.t);
-       set_star_EJ(k);
-       *VKO = sqrt(vs[1]*vs[1]+vs[2]*vs[2]+vs[3]*vs[3]);
-    } else {
-    /* Two kicks */
-       star[k].vr += vs[3] * 1.0e5 / (units.l/units.t) + vs[7] * 1.0e5 / (units.l/units.t);
-       vt_add_kick(&(star[k].vt),vs[1],vs[2], curr_st);
-       vt_add_kick(&(star[k].vt),vs[5],vs[6], curr_st);//will mean a different angle for each kick, should be ok as this is a randomised process...
-       //star[k].vt += sqrt(vs[1]*vs[1]+vs[2]*vs[2]) * 1.0e5 / (units.l/units.t) + sqrt(vs[5]*vs[5]+vs[6]*vs[6]) * 1.0e5 / (units.l/units.t);
-       set_star_EJ(k);
-       *VKO = sqrt(vs[1]*vs[1] + vs[2]*vs[2] + vs[3]*vs[3]) + sqrt(vs[5]*vs[5]+vs[6]*vs[6]+vs[7]*vs[7]);
+    for (int sn = 0; sn < 2; sn++) {
+        /* kick_info[0][sn] is SN ID */
+        if (kick_info[0][sn] > 0.0) { 
+          /* Cols 6-8: shared COM kick */
+          star[k].vr += kick_info[8][sn] * 1.0e5 / (units.l/units.t);
+          vt_add_kick(&(star[k].vt), kick_info[6][sn], kick_info[7][sn], curr_st); //will mean a different angle for each kick, should be ok as this is a randomised process.
+                
+          *VKO += sqrt(kick_info[6][sn]*kick_info[6][sn] + 
+                       kick_info[7][sn]*kick_info[7][sn] + 
+                       kick_info[8][sn]*kick_info[8][sn]);
+        }
     }
-    if (sqrt(vs[1]*vs[1]+vs[2]*vs[2]+vs[3]*vs[3]) != 0.0) {
-      //dprintf("birth kick of %f km/s\n", sqrt(vs[0]*vs[0]+vs[1]*vs[1]+vs[2]*vs[2]));
-  dprintf("birth kick(bin): TT=%.18g, vs[0]=%.18g, vs[1]=%.18g, vs[2]=%.18g, vs[3]=%.18g, vr=%.18g, vt=%.18g VK=%.18g id1=%ld id2=%ld pid1=%ld pid2=%ld type1=%d type2=%d \n",TotalTime,vs[0],vs[1],vs[2],vs[3],star[k].vr,star[k].vt,VKO,binary[kb].id1,binary[kb].id2,binary[kb].id1,binary[kb].id2, binary[kb].bse_kw[0], binary[kb].bse_kw[1]);
+    set_star_EJ(k);
+
+    if (kick_info[2][0] != 0.0) {
+        //dprintf("birth kick of %f km/s\n", kick_info[2][0]);
+      dprintf("birth kick(bin1): TT=%.18g, kick_info[0][0]=%.18g, kick_info[6][0]=%.18g, kick_info[7][0]=%.18g, kick_info[8][0]=%.18g, vr=%.18g, vt=%.18g VK=%.18g id1=%ld id2=%ld pid1=%ld pid2=%ld type1=%d type2=%d \n",TotalTime,kick_info[0][0],kick_info[6][0],kick_info[7][0],kick_info[8][0],star[k].vr,star[k].vt,VKO,binary[kb].id1,binary[kb].id2,binary[kb].id1,binary[kb].id2, binary[kb].bse_kw[0], binary[kb].bse_kw[1]);
     }
+    if (kick_info[2][1] != 0.0) {
+        dprintf("birth kick(bin2): TT=%.18g, kick_info[0][1]=%.18g, kick_info[6][1]=%.18g, kick_info[7][1]=%.18g, kick_info[8][1]=%.18g, vr=%.18g, vt=%.18g VK=%.18g id1=%ld id2=%ld pid1=%ld pid2=%ld type1=%d type2=%d \n",TotalTime,kick_info[0][1],kick_info[6][1],kick_info[7][1],kick_info[8][1],star[k].vr,star[k].vt,VKO,binary[kb].id1,binary[kb].id2,binary[kb].id1,binary[kb].id2, binary[kb].bse_kw[0], binary[kb].bse_kw[1]);
+    }
+        
     /* extract some binary info from BSE's bcm array */
 //    j = 1;
 //    while (bse_get_bcm(j, 1) >= 0.0) {
@@ -1000,110 +997,54 @@ void handle_bse_outcome(long k, long kb, double *vs, double tphysf, int kprev0, 
 		star_r[get_global_idx(k)], kprev0, kprev1, binary[kb].rad1 * units.l / RSUN, binary[kb].rad2 * units.l / RSUN);
 
     destroy_obj(k);
-    /* in this case vs is relative speed between stars at infinity */
-/*    star[knew].vr += star[knewp].m/(star[knew].m+star[knewp].m) * vs[2] * 1.0e5 / (units.l/units.t);
-    star[knew].vt += star[knewp].m/(star[knew].m+star[knewp].m) * sqrt(vs[0]*vs[0]+vs[1]*vs[1]) * 1.0e5 / (units.l/units.t);
+
+    double vko_sq = 0.0; // Track the squares for the legacy quadrature sum
+    for (int sn = 0; sn < 2; sn++) {
+        if (kick_info[0][sn] > 0.0) {
+                
+            /* kick_info[1][sn] is Disrupted Flag (0=no, 1=yes) */
+            if (kick_info[1][sn] == 0.0) {
+            /* System survived THIS kick, both stars get the COM velocity (Cols 6-8) */
+                star[knew].vr += kick_info[8][sn] * 1.0e5 / (units.l/units.t);
+                vt_add_kick(&(star[knew].vt), kick_info[6][sn], kick_info[7][sn], curr_st);
+                    
+                star[knewp].vr += kick_info[8][sn] * 1.0e5 / (units.l/units.t);
+                star[knewp].vt = star[knew].vt; // Tangent speeds sync when sharing COM
+                    
+            } else {
+                /* System disrupted by THIS kick. Apply runaway vectors by Star ID */
+                    
+                /* Star 1 (knew) always gets Cols 6-8 */
+                star[knew].vr += kick_info[8][sn] * 1.0e5 / (units.l/units.t);
+                vt_add_kick(&(star[knew].vt), kick_info[6][sn], kick_info[7][sn], curr_st);
+                    
+                /* Star 2 (knewp) always gets Cols 10-12 */
+                star[knewp].vr += kick_info[12][sn] * 1.0e5 / (units.l/units.t);
+                vt_add_kick(&(star[knewp].vt), kick_info[10][sn], kick_info[11][sn], curr_st);
+            }        
+            
+            // Legacy Disrupted Math: Only track Star 1's columns (6-8) as a sum of squares
+            vko_sq += sqrt(kick_info[6][sn]*kick_info[6][sn] + 
+                           kick_info[7][sn]*kick_info[7][sn] + 
+                           kick_info[8][sn]*kick_info[8][sn]); 
+            
+        }
+    }
+    // Finalize the legacy VKO calculation outside the loop
+    *VKO = sqrt(vko_sq);    
+    
     set_star_EJ(knew);
-    star[knewp].vr += -star[knew].m/(star[knew].m+star[knewp].m) * vs[2] * 1.0e5 / (units.l/units.t);
-    star[knewp].vt += -star[knew].m/(star[knew].m+star[knewp].m) * sqrt(vs[0]*vs[0]+vs[1]*vs[1]) * 1.0e5 / (units.l/units.t);
-    set_star_EJ(knewp);
-*/
-    /* vs is now the recoil speed of both runaway stars owing to SN disruption */
-    if (vs[4]>0.0 && vs[8]<=0.0 ) {
-      /* 1 kick occured and it disrupted the system */
-        if (vs[0]==1) {
-      /* Star knew went SN */
-            star[knew].vr += vs[3] * 1.0e5 / (units.l/units.t);
-            //star[knew].vt += sqrt(vs[1]*vs[1]+vs[2]*vs[2]) * 1.0e5 / (units.l/units.t);
+    set_star_EJ(knewp);    
 
-            vt_add_kick(&(star[knew].vt),vs[1],vs[2], curr_st);
-            set_star_EJ(knew);
-            *VKO = sqrt(vs[1]*vs[1]+vs[2]*vs[2]+vs[3]*vs[3]);
-            star[knewp].vr += vs[7] * 1.0e5 / (units.l/units.t);
-            vt_add_kick(&(star[knewp].vt),vs[5],vs[6], curr_st);
-            //star[knewp].vt += sqrt(vs[5]*vs[5]+vs[6]*vs[6]) * 1.0e5 / (units.l/units.t); 
-            set_star_EJ(knewp);
-        } else {
-       /* Star knewp went SN */
-            star[knewp].vr += vs[3] * 1.0e5 / (units.l/units.t);
-            vt_add_kick(&(star[knewp].vt),vs[1],vs[2], curr_st);
-            //star[knewp].vt += sqrt(vs[1]*vs[1]+vs[2]*vs[2]) * 1.0e5 / (units.l/units.t);
-            set_star_EJ(knewp);
-            *VKO = sqrt(vs[1]*vs[1]+vs[2]*vs[2]+vs[3]*vs[3]);
-            star[knew].vr += vs[7] * 1.0e5 / (units.l/units.t);
-            vt_add_kick(&(star[knew].vt),vs[5],vs[6], curr_st);
-            //star[knew].vt += sqrt(vs[5]*vs[5]+vs[6]*vs[6]) * 1.0e5 / (units.l/units.t); //minus at front?
-            set_star_EJ(knew);
-        }
-    } else if ((vs[4]>0.0 && vs[8]>0.0) && (vs[4] == vs[8])) {
-      /* Two SNe and the 2nd one disrupts the system. 
-         Thus the primary receives vs[1-3] and vs[9-11] secondary receives vs[1-3] and vs[5-7] */
-        if (vs[0]==1) {
-            star[knew].vr += vs[3] * 1.0e5 / (units.l/units.t) + vs[11] * 1.0e5 / (units.l/units.t);
-            vt_add_kick(&(star[knew].vt),vs[1],vs[2], curr_st);
-            star[knewp].vt = star[knew].vt; //update, now seperate companion tangent velocity, after first SN when still part of binary here.
-            vt_add_kick(&(star[knew].vt),vs[9],vs[10], curr_st);
-            //star[knew].vt += sqrt(vs[1]*vs[1]+vs[2]*vs[2]) * 1.0e5 / (units.l/units.t) + sqrt(vs[9]*vs[9]+vs[10]*vs[10]) * 1.0e5 / (units.l/units.t);
-            set_star_EJ(knew);
-            *VKO = sqrt(vs[1]*vs[1]+vs[2]*vs[2]+vs[3]*vs[3]+vs[9]*vs[9]+vs[10]*vs[10]+vs[11]*vs[11]);
-            star[knewp].vr += vs[3] * 1.0e5 / (units.l/units.t) + vs[7] * 1.0e5 / (units.l/units.t);
-            vt_add_kick(&(star[knewp].vt),vs[5],vs[6], curr_st);//finalise companion vt...
+    if (kick_info[2][0] != 0.0) {
+      //dprintf("birth kick of %f km/s\n", kick_info[2][0]);
+      dprintf("birth kick(bin2iso1): TT=%.18g, kick_info[0][0]=%.18g, kick_info[6][0]=%.18g, kick_info[7][0]=%.18g, kick_info[8][0]=%.18g, vr=%.18g, vt=%.18g, VK=%.18g id1=%ld id2=%ld pid1=%ld pid2=%ld type1=%d type2=%d\n",TotalTime,kick_info[0][0],kick_info[6][0],kick_info[7][0],kick_info[8][0],star[k].vr,star[k].vt,VKO,star[knew].id,star[knew].id,binary[kb].id1,binary[kb].id2,star[knew].se_k,star[knewp].se_k);
+    }
+    if (kick_info[2][1] != 0.0) {
+      //dprintf("birth kick of %f km/s\n", kick_info[2][0]);
+      dprintf("birth kick(bin2iso2): TT=%.18g, kick_info[0][1]=%.18g, kick_info[6][1]=%.18g, kick_info[7][1]=%.18g, kick_info[8][1]=%.18g, vr=%.18g, vt=%.18g, VK=%.18g id1=%ld id2=%ld pid1=%ld pid2=%ld type1=%d type2=%d\n",TotalTime,kick_info[0][1],kick_info[6][1],kick_info[7][1],kick_info[8][1],star[k].vr,star[k].vt,VKO,star[knew].id,star[knew].id,binary[kb].id1,binary[kb].id2,star[knew].se_k,star[knewp].se_k);
+    }
 
-            //star[knewp].vt += sqrt(vs[1]*vs[1]+vs[2]*vs[2]) * 1.0e5 / (units.l/units.t) + sqrt(vs[5]*vs[5]+vs[6]*vs[6]) * 1.0e5 / (units.l/units.t);
-            set_star_EJ(knewp);
-        } else {
-            star[knewp].vr += vs[3] * 1.0e5 / (units.l/units.t) + vs[11] * 1.0e5 / (units.l/units.t);
-            vt_add_kick(&(star[knewp].vt),vs[1],vs[2], curr_st);
-            star[knew].vt = star[knewp].vt;
-            vt_add_kick(&(star[knewp].vt),vs[9],vs[10], curr_st);
-            //star[knewp].vt += sqrt(vs[1]*vs[1]+vs[2]*vs[2]) * 1.0e5 / (units.l/units.t) + sqrt(vs[9]*vs[9]+vs[10]*vs[10]) * 1.0e5 / (units.l/units.t);
-            set_star_EJ(knewp);
-            *VKO = sqrt(vs[1]*vs[1]+vs[2]*vs[2]+vs[3]*vs[3]+vs[9]*vs[9]+vs[10]*vs[10]+vs[11]*vs[11]);
-            star[knew].vr += vs[3] * 1.0e5 / (units.l/units.t) + vs[7] * 1.0e5 / (units.l/units.t);
-            vt_add_kick(&(star[knew].vt),vs[5],vs[6], curr_st);
-            //star[knew].vt += sqrt(vs[1]*vs[1]+vs[2]*vs[2]) * 1.0e5 / (units.l/units.t) + sqrt(vs[5]*vs[5]+vs[6]*vs[6]) * 1.0e5 / (units.l/units.t);
-            set_star_EJ(knew);
-        }
-    } else if ((vs[4]>0.0 && vs[8]>0.0) && (vs[4] != vs[8])) {
-      /* Two SNe and the 1st one disrupts the system.
-         Primary feels vs[1-3] and secondary feels vs[5-7] and vs[9-11]. */
-        if (vs[0]==1) {
-            star[knew].vr += vs[3] * 1.0e5 / (units.l/units.t);
-            //star[knew].vt += sqrt(vs[1]*vs[1]+vs[2]*vs[2]) * 1.0e5 / (units.l/units.t);
-            vt_add_kick(&(star[knew].vt),vs[1],vs[2], curr_st);
-            set_star_EJ(knew);
-            *VKO = sqrt(vs[1]*vs[1]+vs[2]*vs[2]+vs[3]*vs[3]);
-            star[knewp].vr += vs[7] * 1.0e5 / (units.l/units.t) + vs[11] * 1.0e5 / (units.l/units.t);
-            vt_add_kick(&(star[knewp].vt),vs[5],vs[6], curr_st);
-            vt_add_kick(&(star[knewp].vt),vs[9],vs[10], curr_st);
-            //star[knewp].vt += sqrt(vs[5]*vs[5]+vs[6]*vs[6]) * 1.0e5 / (units.l/units.t) + sqrt(vs[9]*vs[9]+vs[10]*vs[10]) * 1.0e5 / (units.l/units.t);
-            set_star_EJ(knewp);
-        } else {
-            star[knewp].vr += vs[3] * 1.0e5 / (units.l/units.t);
-            vt_add_kick(&(star[knewp].vt),vs[1],vs[2], curr_st);
-            //star[knewp].vt += sqrt(vs[1]*vs[1]+vs[2]*vs[2]) * 1.0e5 / (units.l/units.t);
-            set_star_EJ(knewp);
-            *VKO = sqrt(vs[1]*vs[1]+vs[2]*vs[2]+vs[3]*vs[3]);
-            star[knew].vr += vs[7] * 1.0e5 / (units.l/units.t) + vs[11] * 1.0e5 / (units.l/units.t);
-            vt_add_kick(&(star[knew].vt),vs[5],vs[6], curr_st);
-            vt_add_kick(&(star[knew].vt),vs[9],vs[10], curr_st);
-            //star[knew].vt += sqrt(vs[5]*vs[5]+vs[6]*vs[6]) * 1.0e5 / (units.l/units.t) + sqrt(vs[9]*vs[9]+vs[10]*vs[10]) * 1.0e5 / (units.l/units.t);
-            set_star_EJ(knew);
-        }
-    } else {
-      /* No kick */
-        star[knew].vr += 0.0;
-        star[knew].vt += 0.0;
-        set_star_EJ(knew);
-        *VKO = 0.0;
-        star[knewp].vr += 0.0;
-        star[knewp].vt += 0.0;
-        set_star_EJ(knewp);
-    }
-    if (sqrt(vs[1]*vs[1]+vs[2]*vs[2]+vs[3]*vs[3]) != 0.0) {
-      //dprintf("birth kick of %f km/s\n", sqrt(vs[0]*vs[0]+vs[1]*vs[1]+vs[2]*vs[2]));
-      dprintf("birth kick(iso1.2): TT=%.18g, vs[0]=%.18g, vs[1]=%.18g, vs[2]=%.18g, vs[3]=%.18g, vr=%.18g, vt=%.18g, VK=%.18g id1=%ld id2=%ld pid1=%ld pid2=%ld type1=%d type2=%d\n",TotalTime,vs[0],vs[1],vs[2],vs[3],star[k].vr,star[k].vt,VKO,star[knew].id,star[knew].id,binary[kb].id1,binary[kb].id2,star[knew].se_k,star[knewp].se_k);
-    }
   } else if (binary[kb].bse_mass[0] != 0.0 && binary[kb].bse_mass[1] == 0.0) {
     /* secondary star gone */
     knew = create_star(k, 1);
@@ -1122,48 +1063,26 @@ void handle_bse_outcome(long k, long kb, double *vs, double tphysf, int kprev0, 
 		star_r[get_global_idx(k)], star[knew].se_k, kprev0, kprev1,
 		star[knew].rad * units.l/ RSUN, binary[kb].rad1 * units.l / RSUN,binary[kb].rad2 * units.l / RSUN);
     destroy_obj(k);
-    if (sqrt(vs[1]*vs[1]+vs[2]*vs[2]+vs[3]*vs[3]) != 0.0) {
-      //dprintf("birth kick of %f km/s\n", sqrt(vs[0]*vs[0]+vs[1]*vs[1]+vs[2]*vs[2]));
+    if (kick_info[2][0] != 0.0) {
+      //dprintf("birth kick of %f km/s\n", kick_info[2][0]);
     }
+    
+    for (int sn = 0; sn < 2; sn++) {
+        if (kick_info[0][sn] > 0.0) {
+            /* Surviving star acts as the COM, gets Cols 6-8 */
+            star[knew].vr += kick_info[8][sn] * 1.0e5 / (units.l/units.t);
+            vt_add_kick(&(star[knew].vt), kick_info[6][sn], kick_info[7][sn], curr_st);
+                
+            *VKO += sqrt(kick_info[6][sn]*kick_info[6][sn] + 
+                         kick_info[7][sn]*kick_info[7][sn] + 
+                         kick_info[8][sn]*kick_info[8][sn]);
+        }
+    }
+    set_star_EJ(knew);
 
-/*    star[knew].vr += vs[2] * 1.0e5 / (units.l/units.t);
-    star[knew].vt += sqrt(vs[0]*vs[0]+vs[1]*vs[1]) * 1.0e5 / (units.l/units.t);
-    set_star_EJ(knew); */
-    /* Update velocity owing to kick(s?) - could be overkill here... */
-    if (vs[0]>0.0 && vs[4]<=0.0 ) {
-       /* One SN occured */
-       star[knew].vr += vs[3] * 1.0e5 / (units.l/units.t);
-       vt_add_kick(&(star[knew].vt),vs[1],vs[2], curr_st);
-       //star[knew].vt += sqrt(vs[1]*vs[1]+vs[2]*vs[2]) * 1.0e5 / (units.l/units.t);
-       set_star_EJ(knew);
-       *VKO = sqrt(vs[1]*vs[1]+vs[2]*vs[2]+vs[3]*vs[3]);
-    } else if (vs[0]>0.0 && vs[4]>0.0 && vs[8]<=0.0 && (vs[0]==vs[4])) {
-       /* 1 SN occured disrupted system then one star killed itself */
-       star[knew].vr += vs[3] * 1.0e5 / (units.l/units.t);
-       //star[knew].vt += sqrt(vs[1]*vs[1]+vs[2]*vs[2]) * 1.0e5 / (units.l/units.t);
-       vt_add_kick(&(star[knew].vt),vs[1],vs[2], curr_st);
-       set_star_EJ(knew);
-       *VKO = sqrt(vs[1]*vs[1]+vs[2]*vs[2]+vs[3]*vs[3]);
-    } else if (vs[0]>0.0 && vs[4]>0.0 && vs[8]<=0.0 && (vs[0]!=vs[4])) {
-       /* 2 SNe then system mergers, star feels both kicks (i.e. it is COM) */
-       /* NOTE: merger remnants of double compact (NS or BH) binaries do not receive kicks in BSE as of yet!
-                When it is introduced may have to put new else if statement in here collecting all (different) vs[]'s. */
-       star[knew].vr += vs[3] * 1.0e5 / (units.l/units.t) + vs[7] * 1.0e5 / (units.l/units.t);
-       vt_add_kick(&(star[knew].vt),vs[1],vs[2], curr_st);
-       vt_add_kick(&(star[knew].vt),vs[5],vs[6], curr_st);
-       //star[knew].vt += sqrt(vs[1]*vs[1]+vs[2]*vs[2]) * 1.0e5 / (units.l/units.t) + sqrt(vs[5]*vs[5]+vs[6]*vs[6]) * 1.0e5 / (units.l/units.t);
-       set_star_EJ(knew);
-       *VKO = sqrt(vs[1]*vs[1]+vs[2]*vs[2]+vs[3]*vs[3]+vs[5]*vs[5]+vs[6]*vs[6]+vs[7]*vs[7]);
-    } else {
-      /* No kick - going to set_star_EJ seems overkill (here and elsewhere). */
-       star[knew].vr += 0.0;
-       star[knew].vt += 0.0;
-       set_star_EJ(knew);
-       *VKO = 0.0;
-    }
-    if (sqrt(vs[1]*vs[1]+vs[2]*vs[2]+vs[3]*vs[3]) != 0.0) {
-      //dprintf("birth kick of %f km/s\n", sqrt(vs[0]*vs[0]+vs[1]*vs[1]+vs[2]*vs[2]));
-  dprintf("birth kick(iso2): TT=%.18g, vs[0]=%.18g, vs[1]=%.18g, vs[2]=%.18g, vs[3]=%.18g, vr=%.18g, vt=%.18g, VK=%.18g id1=%ld id2=na pid1=%ld pid2=%ld type1=%d type2=15\n",TotalTime,vs[0],vs[1],vs[2],vs[3],star[k].vr,star[k].vt,VKO,star[knew].id,binary[kb].id1,binary[kb].id2,star[knew].se_k);
+    if (kick_info[2][0] != 0.0) {
+      //dprintf("birth kick of %f km/s\n", kick_info[2][0]);
+  dprintf("birth kick(bin2iso3): TT=%.18g, kick_info[0][0]=%.18g, kick_info[6][0]=%.18g, kick_info[7][0]=%.18g, kick_info[8][0]=%.18g, vr=%.18g, vt=%.18g, VK=%.18g id1=%ld id2=na pid1=%ld pid2=%ld type1=%d type2=15\n",TotalTime,kick_info[0][0],kick_info[6][0],kick_info[7][0],kick_info[8][0],star[k].vr,star[k].vt,VKO,star[knew].id,binary[kb].id1,binary[kb].id2,star[knew].se_k);
     }
     /* here we do a safe single evolve, just in case the remaining star is a non self-consistent merger */
     dtp = tphysf - star[knew].se_tphys;
@@ -1182,21 +1101,6 @@ void handle_bse_outcome(long k, long kb, double *vs, double tphysf, int kprev0, 
     star_m[get_global_idx(knew)] = star[knew].se_mt * MSUN / units.mstar;
     DMse -= star_m[get_global_idx(knew)] * madhoc;
 
-    /* birth kicks */
-    /* ALSO REMOVE BELOW AS WE NOW WONT PRODUCE ANOTHER KICK
-    if (sqrt(vs[1]*vs[1]+vs[2]*vs[2]+vs[3]*vs[3]) != 0.0) {
-      //dprintf("birth kick of %f km/s\n", sqrt(vs[0]*vs[0]+vs[1]*vs[1]+vs[2]*vs[2]));
-    }
-    star[knew].vr += vs[3] * 1.0e5 / (units.l/units.t);
-    vt_add_kick(&(star[knew].vt),vs[1],vs[2]);
-    //star[knew].vt += sqrt(vs[1]*vs[1]+vs[2]*vs[2]) * 1.0e5 / (units.l/units.t);
-    set_star_EJ(knew);
-    VKO = sqrt(vs[1]*vs[1]+vs[2]*vs[2]+vs[3]*vs[3]);
-    if (sqrt(vs[1]*vs[1]+vs[2]*vs[2]+vs[3]*vs[3]) != 0.0) {
-      //dprintf("birth kick of %f km/s\n", sqrt(vs[0]*vs[0]+vs[1]*vs[1]+vs[2]*vs[2]));
-  dprintf("birth kick(iso3): TT=%.18g, vs[0]=%.18g, vs[1]=%.18g, vs[2]=%.18g, vs[3]=%.18g, vr=%.18g, vt=%.18g, VKO=%.18g, id=%ld id1=%ld id2=%ld type1=%d type2=15\n",TotalTime,vs[0],vs[1],vs[2],vs[3],star[k].vr,star[k].vt,VKO,star[knew].id,binary[kb].id1,binary[kb].id2,star[knew].se_k);
-    }
-    */
   } else if (binary[kb].bse_mass[0] == 0.0 && binary[kb].bse_mass[1] != 0.0) {
     /* primary star gone */
     //dprintf("binary disrupted via BSE with second star intact\n");
@@ -1216,47 +1120,50 @@ void handle_bse_outcome(long k, long kb, double *vs, double tphysf, int kprev0, 
 		star[knew].rad * units.l / RSUN, binary[kb].rad1 * units.l / RSUN, binary[kb].rad2 * units.l / RSUN);
 
     destroy_obj(k);
-    if (sqrt(vs[1]*vs[1]+vs[2]*vs[2]+vs[3]*vs[3]) != 0.0) {
-      //dprintf("birth kick of %f km/s\n", sqrt(vs[0]*vs[0]+vs[1]*vs[1]+vs[2]*vs[2]));
+    for (int sn = 0; sn < 2; sn++) {
+        if (kick_info[0][sn] > 0.0) {
+            //dprintf("birth kick of %f km/s\n", kick_info[2][sn]);
+        }
     }
-/*    star[knew].vr += vs[2] * 1.0e5 / (units.l/units.t);
-    star[knew].vt += sqrt(vs[0]*vs[0]+vs[1]*vs[1]) * 1.0e5 / (units.l/units.t);
-    set_star_EJ(knew); */
-    /* Update velocity owing to kick(s?) - could be overkill here... */
-    if (vs[0]>0.0 && vs[4]<=0.0 ) {
-       /* One SN occured */
-       star[knew].vr += vs[3] * 1.0e5 / (units.l/units.t);
-       vt_add_kick(&(star[knew].vt),vs[1],vs[2], curr_st);
-       //star[knew].vt += sqrt(vs[1]*vs[1]+vs[2]*vs[2]) * 1.0e5 / (units.l/units.t);
-       set_star_EJ(knew);
-       *VKO = sqrt(vs[1]*vs[1]+vs[2]*vs[2]+vs[3]*vs[3]);
-    } else if (vs[0]>0.0 && vs[4]>0.0 && vs[8]<=0.0 && (vs[0]==vs[4])) {
-       /* 1 SN occured disrupted system then one star killed itself */
-       star[knew].vr += vs[3] * 1.0e5 / (units.l/units.t);
-       vt_add_kick(&(star[knew].vt),vs[1],vs[2], curr_st);
-       //star[knew].vt += sqrt(vs[1]*vs[1]+vs[2]*vs[2]) * 1.0e5 / (units.l/units.t);
-       set_star_EJ(knew);
-       *VKO = sqrt(vs[1]*vs[1]+vs[2]*vs[2]+vs[3]*vs[3]);
-    } else if (vs[0]>0.0 && vs[4]>0.0 && vs[8]<=0.0 && (vs[0]!=vs[4])) {
-       /* 2 SNe then system mergers, star feels both kicks (i.e. it is COM) */
-       /* NOTE: merger remnants of double compact (NS or BH) binaries do not receive kicks in BSE as of yet!
-                When it is introduced may have to put new else if statement in here collecting all (different) vs[]'s. */
-       star[knew].vr += vs[3] * 1.0e5 / (units.l/units.t) + vs[7] * 1.0e5 / (units.l/units.t);
-       vt_add_kick(&(star[knew].vt),vs[1],vs[2], curr_st);
-       vt_add_kick(&(star[knew].vt),vs[5],vs[6], curr_st);
-       //star[knew].vt += sqrt(vs[1]*vs[1]+vs[2]*vs[2]) * 1.0e5 / (units.l/units.t) + sqrt(vs[5]*vs[5]+vs[6]*vs[6]) * 1.0e5 / (units.l/units.t);
-       set_star_EJ(knew);
-       *VKO = sqrt(vs[1]*vs[1]+vs[2]*vs[2]+vs[3]*vs[3]+vs[5]*vs[5]+vs[6]*vs[6]+vs[7]*vs[7]);
-    } else {
-      /* No kick - going to set_star_EJ seems overkill (here and elsewhere). */
-       star[knew].vr += 0.0;
-       star[knew].vt += 0.0;
-       set_star_EJ(knew);
-       *VKO = 0.0;
+
+    double vko_sq = 0.0; // Track squares for legacy quadrature sum
+
+    for (int sn = 0; sn < 2; sn++) {
+        if (kick_info[0][sn] > 0.0) {
+            
+            /* Column 1 is the Disrupted Flag (0=no, 1=yes) */
+            if (kick_info[1][sn] == 0.0) {
+                /* System merged or survived THIS kick. 
+ *                    Surviving Star 2 acts as COM, gets Cols 6-8 */
+                star[knew].vr += kick_info[8][sn] * 1.0e5 / (units.l/units.t);
+                vt_add_kick(&(star[knew].vt), kick_info[6][sn], kick_info[7][sn], curr_st);
+                
+                vko_sq += (kick_info[6][sn]*kick_info[6][sn] + 
+                           kick_info[7][sn]*kick_info[7][sn] + 
+                           kick_info[8][sn]*kick_info[8][sn]);
+                           
+            } else {
+                /* System disrupted by THIS kick, and then Star 1 vanished.
+ *                    Surviving Star 2 gets its specific runaway vectors from Cols 10-12 */
+                star[knew].vr += kick_info[12][sn] * 1.0e5 / (units.l/units.t);
+                vt_add_kick(&(star[knew].vt), kick_info[10][sn], kick_info[11][sn], curr_st);
+                
+                vko_sq += (kick_info[10][sn]*kick_info[10][sn] + 
+                           kick_info[11][sn]*kick_info[11][sn] + 
+                           kick_info[12][sn]*kick_info[12][sn]);
+            }
+        }
     }
-    if (sqrt(vs[1]*vs[1]+vs[2]*vs[2]+vs[3]*vs[3]) != 0.0) {
-      //dprintf("birth kick of %f km/s\n", sqrt(vs[0]*vs[0]+vs[1]*vs[1]+vs[2]*vs[2]));
-  dprintf("birth kick(iso4): TT=%.18g, vs[0]=%.18g, vs[1]=%.18g, vs[2]=%.18g, vs[3]=%.18g, vr=%.18g, vt=%.18g, VKO=%.18g id=%ld id1=%ld id2=%ld type1=15 type2=%d\n",TotalTime,vs[0],vs[1],vs[2],vs[3],star[k].vr,star[k].vt,VKO, star[knew].id, binary[kb].id1, binary[kb].id2, star[knew].se_k);
+    
+    // Finalize legacy VKO calculation
+    *VKO = sqrt(vko_sq);         
+    set_star_EJ(knew);
+
+    for (int sn = 0; sn < 2; sn++) {
+        if (kick_info[0][sn] > 0.0) {
+            //dprintf("birth kick of %f km/s\n", kick_info[0][sn]);
+            dprintf("birth kick(bin2iso4): TT=%.18g, kick_info[0][sn]=%.18g, kick_info[6][sn]=%.18g, kick_info[7][sn]=%.18g, kick_info[8][sn]=%.18g, vr=%.18g, vt=%.18g, VKO=%.18g id=%ld id1=%ld id2=%ld type1=15 type2=%d\n",TotalTime,kick_info[0][sn],kick_info[6][sn],kick_info[7][sn],kick_info[8][sn],star[k].vr,star[k].vt,VKO, star[knew].id, binary[kb].id1, binary[kb].id2, star[knew].se_k);
+        }
     }
     
     /* here we do a safe single evolve, just in case the remaining star is a non self-consistent merger */
@@ -1276,21 +1183,6 @@ void handle_bse_outcome(long k, long kb, double *vs, double tphysf, int kprev0, 
     star_m[get_global_idx(knew)] = star[knew].se_mt * MSUN / units.mstar;
     DMse -= star_m[get_global_idx(knew)] * madhoc;
 
-    /* birth kicks */
-    /* REMOVED AGAIN NOT TO ADD KICK AGAIN
-    if (sqrt(vs[1]*vs[1]+vs[2]*vs[2]+vs[3]*vs[3]) != 0.0) {
-      //dprintf("birth kick of %f km/s\n", sqrt(vs[0]*vs[0]+vs[1]*vs[1]+vs[2]*vs[2]));
-    }
-    star[knew].vr += vs[3] * 1.0e5 / (units.l/units.t);
-    vt_add_kick(&(star[knew].vt),vs[1],vs[2]);
-    //star[knew].vt += sqrt(vs[1]*vs[1]+vs[2]*vs[2]) * 1.0e5 / (units.l/units.t);
-    set_star_EJ(knew);
-    VKO = sqrt(vs[1]*vs[1]+vs[2]*vs[2]+vs[3]*vs[3]);
-    if (sqrt(vs[1]*vs[1]+vs[2]*vs[2]+vs[3]*vs[3]) != 0.0) {
-      //dprintf("birth kick of %f km/s\n", sqrt(vs[0]*vs[0]+vs[1]*vs[1]+vs[2]*vs[2]));
-  dprintf("birth kick(iso6): TT=%.18g, vs[0]=%.18g, vs[1]=%.18g, vs[2]=%.18g, vs[3]=%.18g, vr=%.18g, vt=%.18g, VK=%.18g type1=15 type2=%d\n",TotalTime,vs[0],vs[1],vs[2],vs[3],star[k].vr,star[k].vt,VKO,star[knew].se_k);
-    }
-    */
   } else if (binary[kb].bse_mass[0] == 0.0 && binary[kb].bse_mass[1] == 0.0) {
     /* both stars gone */
     //dprintf("binary disrupted via BSE with no stars intact\n");
@@ -1315,7 +1207,7 @@ void handle_bse_outcome(long k, long kb, double *vs, double tphysf, int kprev0, 
     exit_cleanly(-1, __FUNCTION__);
   }
 
-	/*Shi*/
+	/*CSY*/
 	if(tcount%PULSAR_DELTACOUNT==0){
 		if (WRITE_MOREPULSAR_INFO){
         		if (knew){

--- a/src/cmc/cmc_stellar_evolution.c
+++ b/src/cmc/cmc_stellar_evolution.c
@@ -596,10 +596,10 @@ void do_stellar_evolution(gsl_rng *rng)
         
 	/* PDK search for boom stuff and write pulsar data. */
 		//bcm_boom_search(k, vs, getCMCvalues);
-		if(WRITE_PULSAR_INFO)
-		{
-			pulsar_write(k, VKO);
-		}
+		//if(WRITE_PULSAR_INFO)
+		//{
+			//pulsar_write(k, VKO);
+		//}
 
 		//CSY
 		if(tcount%PULSAR_DELTACOUNT==0){
@@ -1287,16 +1287,16 @@ void handle_bse_outcome(long k, long kb, double kick_info[19][2], double tphysf,
     dprintf("unhandled binary outcome!\n");
   /* End by looking for boom stuff to log and log pulsar info */
 
-	 if(WRITE_PULSAR_INFO)
-	 {
-		 if (knew) {
-			 //bcm_boom_search(knew, vs, getCMCvalues);
-			 pulsar_write(knew,  *VKO);
-		 } else {
-			 //bcm_boom_search(k, vs, getCMCvalues);
-			 pulsar_write(k,  *VKO);
-		 }
-	 }
+	 //if(WRITE_PULSAR_INFO)
+	 //{
+	//	 if (knew) {
+	//		 //bcm_boom_search(knew, vs, getCMCvalues);
+	//		 pulsar_write(knew,  *VKO);
+	//	 } else {
+	//		 //bcm_boom_search(k, vs, getCMCvalues);
+	//		 pulsar_write(k,  *VKO);
+	//	 }
+	// }
 
 	 dprintf("bse_mass0=%g bse_mass1=%g tb=%g\n",
       binary[kb].bse_mass[0], binary[kb].bse_mass[1], binary[kb].bse_tb);

--- a/src/cmc/cmc_stellar_evolution.c
+++ b/src/cmc/cmc_stellar_evolution.c
@@ -15,6 +15,7 @@
 */
 void restart_stellar_evolution(void){
   bse_set_using_cmc();
+  bse_init_umax();
   bse_set_neta(BSE_NETA);
   bse_set_bwind(BSE_BWIND);
   bse_set_hewind(BSE_HEWIND);
@@ -113,6 +114,7 @@ void stellar_evolution_init(void){
 
   /* BSE */
   bse_set_using_cmc();
+  bse_init_umax();
   bse_set_neta(BSE_NETA);
   bse_set_bwind(BSE_BWIND);
   bse_set_hewind(BSE_HEWIND);

--- a/src/cmc/cmc_stellar_evolution.c
+++ b/src/cmc/cmc_stellar_evolution.c
@@ -121,7 +121,7 @@ void stellar_evolution_init(void){
   int kprev0=-100;
   int kprev1=-100;
   binary_t tempbinary;
-  double VKO;
+  double VKO[2] = {0.0, 0.0};
 
   /* SSE */
   /* bse_set_hewind(0.5); */
@@ -376,7 +376,7 @@ void stellar_evolution_init(void){
       *curr_st=bse_get_taus113state();
 
 
-      handle_bse_outcome(k, kb, kick_info, tphysf, kprev0, kprev1, &VKO);
+      handle_bse_outcome(k, kb, kick_info, tphysf, kprev0, kprev1, VKO);
 
 
     } else {
@@ -404,7 +404,7 @@ void do_stellar_evolution(gsl_rng *rng)
   long k, kb, j, jj;
   int kprev,i, ii, kk;
   int kprev0, kprev1;
-  double dtp, tphysf, kick_info[19][2], VKO;
+  double dtp, tphysf, kick_info[19][2], VKO[2] = {0.0, 0.0};
   double M_beforeSE, M10_beforeSE, M100_beforeSE, M1000_beforeSE, Mcore_beforeSE;
   double M_afterSE, M10_afterSE, M100_afterSE, M1000_afterSE, Mcore_afterSE;
   double r10_beforeSE, r100_beforeSE, r1000_beforeSE, rcore_beforeSE;
@@ -578,11 +578,11 @@ void do_stellar_evolution(gsl_rng *rng)
         vt_add_kick(&(star[k].vt),kick_info[6][0],kick_info[7][0], curr_st);
         
         set_star_EJ(k);
-        VKO = sqrt(kick_info[6][0]*kick_info[6][0] + kick_info[7][0]*kick_info[7][0] + kick_info[8][0]*kick_info[8][0]);
+        VKO[0] = sqrt(kick_info[6][0]*kick_info[6][0] + kick_info[7][0]*kick_info[7][0] + kick_info[8][0]*kick_info[8][0]);
         /* birth kicks */
         if (kick_info[2][0] != 0.0) {
           //   dprintf("birth kick of %f km/s\n", kick_info[2][0]);
-          dprintf("birth kick(iso): TT=%.18g, kick_info[0][0]=%.18g, kick_info[6][0]=%.18g, kick_info[7][0]=%.18g, kick_info[8][0]=%.18g, vr=%.18g, vt=%.18g VKO=%.18g type=%d star_id=%ld Pi=%g\n",TotalTime,kick_info[0][0],kick_info[6][0],kick_info[7][0],kick_info[8][0],star[k].vr,star[k].vt,VKO,star[k].se_k, star[k].id,star[k].se_ospin);
+          dprintf("birth kick(iso): TT=%.18g, kick_info[0][0]=%.18g, kick_info[6][0]=%.18g, kick_info[7][0]=%.18g, kick_info[8][0]=%.18g, vr=%.18g, vt=%.18g VKO=%.18g type=%d star_id=%ld Pi=%g\n",TotalTime,kick_info[0][0],kick_info[6][0],kick_info[7][0],kick_info[8][0],star[k].vr,star[k].vt,VKO[0],star[k].se_k, star[k].id,star[k].se_ospin);
         }
 
         /* WD birth kicks, just in case they exist */
@@ -610,7 +610,7 @@ void do_stellar_evolution(gsl_rng *rng)
 
     if (WRITE_MOREPULSAR_INFO) {
             if (kprev!=13 && star[k].se_k==13) { // newly formed NS
-                    parafprintf(newnsfile, "%.18g %g 0 %ld %g %g %g %g %g %d", TotalTime, star_r[g_k], star[k].id,star[k].se_zams_mass,star[k].se_mass, star[k].se_mt, star[k].se_scm_formation, VKO, kprev);
+                    parafprintf(newnsfile, "%.18g %g 0 %ld %g %g %g %g %g %d", TotalTime, star_r[g_k], star[k].id,star[k].se_zams_mass,star[k].se_mass, star[k].se_mt, star[k].se_scm_formation, VKO[0], kprev);
 
                     for (ii=0; ii<19; ii++){
                         parafprintf (newnsfile, " %g", kick_info[ii][0]);
@@ -622,7 +622,7 @@ void do_stellar_evolution(gsl_rng *rng)
 
 		if (WRITE_BH_INFO) {
 			if (kprev!=14 && star[k].se_k==14) { // newly formed BH
-				parafprintf(newbhfile, "%.18g %g 0 %ld %g %g %g %g %g", TotalTime, star_r[g_k], star[k].id,star[k].se_zams_mass,star[k].se_mass, star[k].se_mt, star[k].se_bhspin, VKO);
+				parafprintf(newbhfile, "%.18g %g 0 %ld %g %g %g %g %g", TotalTime, star_r[g_k], star[k].id,star[k].se_zams_mass,star[k].se_mass, star[k].se_mt, star[k].se_bhspin, VKO[0]);
 				for (ii=0; ii<19; ii++){
 					parafprintf (newbhfile, " %g", kick_info[ii][0]);
 				}
@@ -716,18 +716,18 @@ void do_stellar_evolution(gsl_rng *rng)
   long prev_id1 = binary[kb].id1;
   long prev_id2 = binary[kb].id2;
        
-	handle_bse_outcome(k, kb, kick_info, tphysf, kprev0, kprev1, &VKO);
+	handle_bse_outcome(k, kb, kick_info, tphysf, kprev0, kprev1, VKO);
 
 	if (WRITE_BH_INFO) {
 		if (kprev0!=14 && binary[kb].bse_kw[0]==14) { // newly formed BH
-			parafprintf(newbhfile, "%.18g %g 1 %ld %g %g %g %g %g", TotalTime, star_r[g_k], prev_id1, binary[kb].bse_zams_mass[0], binary[kb].bse_mass0[0], binary[kb].bse_mass[0], binary[kb].bse_bhspin[0], VKO);
+			parafprintf(newbhfile, "%.18g %g 1 %ld %g %g %g %g %g", TotalTime, star_r[g_k], prev_id1, binary[kb].bse_zams_mass[0], binary[kb].bse_mass0[0], binary[kb].bse_mass[0], binary[kb].bse_bhspin[0], VKO[0]);
 			for (ii=0; ii<19; ii++){
 			    parafprintf (newbhfile, " %g", kick_info[ii][0]);
 			}
 			parafprintf (newbhfile, "\n");
 		}
 		if (kprev1!=14 && binary[kb].bse_kw[1]==14 && binary[kb].id2 != 0) { // newly formed BH
-			parafprintf(newbhfile, "%.18g %g 1 %ld %g %g %g %g %g", TotalTime, star_r[g_k], prev_id2, binary[kb].bse_zams_mass[1],binary[kb].bse_mass0[1], binary[kb].bse_mass[1], binary[kb].bse_bhspin[1],VKO);
+			parafprintf(newbhfile, "%.18g %g 1 %ld %g %g %g %g %g", TotalTime, star_r[g_k], prev_id2, binary[kb].bse_zams_mass[1],binary[kb].bse_mass0[1], binary[kb].bse_mass[1], binary[kb].bse_bhspin[1],VKO[1]);
 			for (ii=0; ii<19; ii++){
 			    parafprintf (newbhfile, " %g", kick_info[ii][1]);
 			}
@@ -737,14 +737,14 @@ void do_stellar_evolution(gsl_rng *rng)
 
         if (WRITE_MOREPULSAR_INFO) {
                 if (kprev0!=13 && binary[kb].bse_kw[0]==13) { // newly formed NS
-                        parafprintf(newnsfile, "%.18g %g 1 %ld %g %g %g %g %g %d", TotalTime, star_r[g_k], prev_id1, binary[kb].bse_zams_mass[0], binary[kb].bse_mass0[0], binary[kb].bse_mass[0], binary[kb].bse_bcm_formation[0], VKO, kprev0);
+                        parafprintf(newnsfile, "%.18g %g 1 %ld %g %g %g %g %g %d", TotalTime, star_r[g_k], prev_id1, binary[kb].bse_zams_mass[0], binary[kb].bse_mass0[0], binary[kb].bse_mass[0], binary[kb].bse_bcm_formation[0], VKO[0], kprev0);
                         for (ii=0; ii<19; ii++){
                             parafprintf (newnsfile, " %g", kick_info[ii][0]);
                         }
                         parafprintf(newnsfile, "\n");
                 }
                 if (kprev1!=13 && binary[kb].bse_kw[1]==13 && binary[kb].id2 != 0) { // newly formed NS
-                        parafprintf(newnsfile, "%.18g %g 1 %ld %g %g %g %g %g %d", TotalTime, star_r[g_k], prev_id2, binary[kb].bse_zams_mass[1],binary[kb].bse_mass0[1], binary[kb].bse_mass[1], binary[kb].bse_bcm_formation[1],VKO,kprev1);
+                        parafprintf(newnsfile, "%.18g %g 1 %ld %g %g %g %g %g %d", TotalTime, star_r[g_k], prev_id2, binary[kb].bse_zams_mass[1],binary[kb].bse_mass0[1], binary[kb].bse_mass[1], binary[kb].bse_bcm_formation[1],VKO[1],kprev1);
                         for (ii=0; ii<19; ii++){
                             parafprintf (newnsfile, " %g", kick_info[ii][1]);
                         }
@@ -871,17 +871,18 @@ void write_stellar_data(void){
 * @param kick_info ?
 * @param tphysf ?
 */
-void handle_bse_outcome(long k, long kb, double kick_info[19][2], double tphysf, int kprev0, int kprev1, double *VKO)
+void handle_bse_outcome(long k, long kb, double kick_info[19][2], double tphysf, int kprev0, int kprev1, double VKO[2])
 {
   int j, jj;
   long knew=0, knewp=0, convert;
   double dtp;
-  double vko_sq = 0.0; //Track the square of the legacy quadrature sum
   double knew_vtx = 0.0, knew_vty = 0.0, knew_vtz;
   double knewp_vtx = 0.0, knewp_vty = 0.0, knewp_vtz;
   
+  VKO[0] = 0.0;
+  VKO[1] = 0.0;
   //knew = 0;
-  *VKO = 0.0;
+  //*VKO = 0.0;
 
   /* PK: extract some stellar/binary info from BSE's bcm array */
   /* but don't loop forever, just until maximum array length.  */
@@ -996,7 +997,8 @@ void handle_bse_outcome(long k, long kb, double kick_info[19][2], double tphysf,
         }
     }
     
-    *VKO = sqrt(total_vtx*total_vtx + total_vty*total_vty + total_vtz*total_vtz);
+    VKO[0] = sqrt(total_vtx*total_vtx + total_vty*total_vty + total_vtz*total_vtz);
+    VKO[1] = VKO[0];    
 
     /* Apply the random rotation to the true vector sum ONCE */
     if (total_vtx != 0.0 || total_vty != 0.0) {
@@ -1007,10 +1009,10 @@ void handle_bse_outcome(long k, long kb, double kick_info[19][2], double tphysf,
 
     if (kick_info[2][0] != 0.0) {
         //dprintf("birth kick of %f km/s\n", kick_info[2][0]);
-      dprintf("birth kick(bin1): TT=%.18g, kick_info[0][0]=%.18g, kick_info[6][0]=%.18g, kick_info[7][0]=%.18g, kick_info[8][0]=%.18g, vr=%.18g, vt=%.18g VK=%.18g id1=%ld id2=%ld pid1=%ld pid2=%ld type1=%d type2=%d \n",TotalTime,kick_info[0][0],kick_info[6][0],kick_info[7][0],kick_info[8][0],star[k].vr,star[k].vt,VKO,binary[kb].id1,binary[kb].id2,binary[kb].id1,binary[kb].id2, binary[kb].bse_kw[0], binary[kb].bse_kw[1]);
+      dprintf("birth kick(bin1): TT=%.18g, kick_info[0][0]=%.18g, kick_info[6][0]=%.18g, kick_info[7][0]=%.18g, kick_info[8][0]=%.18g, vr=%.18g, vt=%.18g VK=%.18g id1=%ld id2=%ld pid1=%ld pid2=%ld type1=%d type2=%d \n",TotalTime,kick_info[0][0],kick_info[6][0],kick_info[7][0],kick_info[8][0],star[k].vr,star[k].vt,VKO[0],binary[kb].id1,binary[kb].id2,binary[kb].id1,binary[kb].id2, binary[kb].bse_kw[0], binary[kb].bse_kw[1]);
     }
     if (kick_info[2][1] != 0.0) {
-        dprintf("birth kick(bin2): TT=%.18g, kick_info[0][1]=%.18g, kick_info[6][1]=%.18g, kick_info[7][1]=%.18g, kick_info[8][1]=%.18g, vr=%.18g, vt=%.18g VK=%.18g id1=%ld id2=%ld pid1=%ld pid2=%ld type1=%d type2=%d \n",TotalTime,kick_info[0][1],kick_info[6][1],kick_info[7][1],kick_info[8][1],star[k].vr,star[k].vt,VKO,binary[kb].id1,binary[kb].id2,binary[kb].id1,binary[kb].id2, binary[kb].bse_kw[0], binary[kb].bse_kw[1]);
+        dprintf("birth kick(bin2): TT=%.18g, kick_info[0][1]=%.18g, kick_info[6][1]=%.18g, kick_info[7][1]=%.18g, kick_info[8][1]=%.18g, vr=%.18g, vt=%.18g VK=%.18g id1=%ld id2=%ld pid1=%ld pid2=%ld type1=%d type2=%d \n",TotalTime,kick_info[0][1],kick_info[6][1],kick_info[7][1],kick_info[8][1],star[k].vr,star[k].vt,VKO[1],binary[kb].id1,binary[kb].id2,binary[kb].id1,binary[kb].id2, binary[kb].bse_kw[0], binary[kb].bse_kw[1]);
     }
         
     /* extract some binary info from BSE's bcm array */
@@ -1058,16 +1060,15 @@ void handle_bse_outcome(long k, long kb, double kick_info[19][2], double tphysf,
                 star[knew].vr += kick_info[8][sn] * 1.0e5 / (units.l/units.t);
                 knew_vtx += kick_info[6][sn];
                 knew_vty += kick_info[7][sn];
+                knew_vtz += kick_info[8][sn];
                 //vt_add_kick(&(star[knew].vt), kick_info[6][sn], kick_info[7][sn], curr_st);
                     
                 star[knewp].vr += kick_info[8][sn] * 1.0e5 / (units.l/units.t);
                 knewp_vtx += kick_info[6][sn];
                 knewp_vty += kick_info[7][sn];
+                knewp_vtz += kick_info[8][sn];
                 //star[knewp].vt = star[knew].vt; // Tangent speeds sync when sharing COM
                     
-                vko_sq += (kick_info[6][sn]*kick_info[6][sn] +
-                           kick_info[7][sn]*kick_info[7][sn] +
-                           kick_info[8][sn]*kick_info[8][sn]);
             } else {
                 /* System disrupted by THIS kick. Apply runaway vectors by Star ID */
                     
@@ -1075,35 +1076,25 @@ void handle_bse_outcome(long k, long kb, double kick_info[19][2], double tphysf,
                 star[knew].vr += kick_info[8][sn] * 1.0e5 / (units.l/units.t);
                 knew_vtx += kick_info[6][sn];
                 knew_vty += kick_info[7][sn];
+                knew_vtz += kick_info[8][sn];
                 //vt_add_kick(&(star[knew].vt), kick_info[6][sn], kick_info[7][sn], curr_st);
                     
                 /* Star 2 (knewp) always gets Cols 10-12 */
                 star[knewp].vr += kick_info[12][sn] * 1.0e5 / (units.l/units.t);
                 knewp_vtx += kick_info[10][sn];
                 knewp_vty += kick_info[11][sn];
+                knewp_vtz += kick_info[12][sn];
                 //vt_add_kick(&(star[knewp].vt), kick_info[10][sn], kick_info[11][sn], curr_st);
                 
-                /* Log the correct star's runaway magnitude */
-                if (sn == 0) {
-                    vko_sq += (kick_info[6][sn]*kick_info[6][sn] +
-                               kick_info[7][sn]*kick_info[7][sn] +
-                               kick_info[8][sn]*kick_info[8][sn]);
-                } else {
-                    vko_sq += (kick_info[10][sn]*kick_info[10][sn] +
-                               kick_info[11][sn]*kick_info[11][sn] +
-                               kick_info[12][sn]*kick_info[12][sn]);
-                }
             }        
             
-            // Legacy Disrupted Math: Only track Star 1's columns (6-8) as a sum of squares
-            //vko_sq += (kick_info[6][sn]*kick_info[6][sn] + 
-            //           kick_info[7][sn]*kick_info[7][sn] + 
-            //           kick_info[8][sn]*kick_info[8][sn]); 
             
         }
     }
-    // Finalize the legacy VKO calculation outside the loop
-    *VKO = sqrt(vko_sq);    
+    /* VKO array records the FINAL net recoil velocities of Star 1 and Star 2 */
+    VKO[0] = sqrt(knew_vtx*knew_vtx + knew_vty*knew_vty + knew_vtz*knew_vtz);
+    VKO[1] = sqrt(knewp_vtx*knewp_vtx + knewp_vty*knewp_vty + knewp_vtz*knewp_vtz);
+    
     /* Apply vectors outside the loop */
     if (knew_vtx != 0.0 || knew_vty != 0.0) {
         vt_add_kick(&(star[knew].vt), knew_vtx, knew_vty, curr_st);
@@ -1117,7 +1108,7 @@ void handle_bse_outcome(long k, long kb, double kick_info[19][2], double tphysf,
 
     if (kick_info[2][0] != 0.0) {
       //dprintf("birth kick of %f km/s\n", kick_info[2][0]);
-      dprintf("birth kick(bin2iso1): TT=%.18g, kick_info[0][0]=%.18g, kick_info[6][0]=%.18g, kick_info[7][0]=%.18g, kick_info[8][0]=%.18g, vr=%.18g, vt=%.18g, VK=%.18g id1=%ld id2=%ld pid1=%ld pid2=%ld type1=%d type2=%d\n",TotalTime,kick_info[0][0],kick_info[6][0],kick_info[7][0],kick_info[8][0],star[k].vr,star[k].vt,VKO,star[knew].id,star[knew].id,binary[kb].id1,binary[kb].id2,star[knew].se_k,star[knewp].se_k);
+      dprintf("birth kick(bin2iso1): TT=%.18g, kick_info[0][0]=%.18g, kick_info[6][0]=%.18g, kick_info[7][0]=%.18g, kick_info[8][0]=%.18g, vr=%.18g, vt=%.18g, VK=%.18g id1=%ld id2=%ld pid1=%ld pid2=%ld type1=%d type2=%d\n",TotalTime,kick_info[0][0],kick_info[6][0],kick_info[7][0],kick_info[8][0],star[k].vr,star[k].vt,VKO[0],star[knew].id,star[knew].id,binary[kb].id1,binary[kb].id2,star[knew].se_k,star[knewp].se_k);
     }
     if (kick_info[2][1] != 0.0) {
       //dprintf("birth kick of %f km/s\n", kick_info[2][0]);
@@ -1156,14 +1147,11 @@ void handle_bse_outcome(long k, long kb, double kick_info[19][2], double tphysf,
             knew_vtz += kick_info[8][sn];
             //vt_add_kick(&(star[knew].vt), kick_info[6][sn], kick_info[7][sn], curr_st);
                 
-            //vko_sq += (kick_info[6][sn]*kick_info[6][sn] + 
-            //           kick_info[7][sn]*kick_info[7][sn] + 
-            //           kick_info[8][sn]*kick_info[8][sn]);
 
         }
     }
-    //*VKO = sqrt(vko_sq);
-    *VKO = sqrt(knew_vtx*knew_vtx + knew_vty*knew_vty + knew_vtz*knew_vtz);
+    VKO[0] = sqrt(knew_vtx*knew_vtx + knew_vty*knew_vty + knew_vtz*knew_vtz);
+    VKO[1] = 0.0;    
 
     if (knew_vtx != 0.0 || knew_vty != 0.0) {
         vt_add_kick(&(star[knew].vt), knew_vtx, knew_vty, curr_st);
@@ -1173,7 +1161,7 @@ void handle_bse_outcome(long k, long kb, double kick_info[19][2], double tphysf,
 
     if (kick_info[2][0] != 0.0) {
       //dprintf("birth kick of %f km/s\n", kick_info[2][0]);
-  dprintf("birth kick(bin2iso3): TT=%.18g, kick_info[0][0]=%.18g, kick_info[6][0]=%.18g, kick_info[7][0]=%.18g, kick_info[8][0]=%.18g, vr=%.18g, vt=%.18g, VK=%.18g id1=%ld id2=na pid1=%ld pid2=%ld type1=%d type2=15\n",TotalTime,kick_info[0][0],kick_info[6][0],kick_info[7][0],kick_info[8][0],star[k].vr,star[k].vt,VKO,star[knew].id,binary[kb].id1,binary[kb].id2,star[knew].se_k);
+  dprintf("birth kick(bin2iso3): TT=%.18g, kick_info[0][0]=%.18g, kick_info[6][0]=%.18g, kick_info[7][0]=%.18g, kick_info[8][0]=%.18g, vr=%.18g, vt=%.18g, VK=%.18g id1=%ld id2=na pid1=%ld pid2=%ld type1=%d type2=15\n",TotalTime,kick_info[0][0],kick_info[6][0],kick_info[7][0],kick_info[8][0],star[k].vr,star[k].vt,VKO[0],star[knew].id,binary[kb].id1,binary[kb].id2,star[knew].se_k);
     }
     /* here we do a safe single evolve, just in case the remaining star is a non self-consistent merger */
     dtp = tphysf - star[knew].se_tphys;
@@ -1230,9 +1218,6 @@ void handle_bse_outcome(long k, long kb, double kick_info[19][2], double tphysf,
                 knew_vtz += kick_info[8][sn];
                 //vt_add_kick(&(star[knew].vt), kick_info[6][sn], kick_info[7][sn], curr_st);
                 
-                //vko_sq += (kick_info[6][sn]*kick_info[6][sn] + 
-                //           kick_info[7][sn]*kick_info[7][sn] + 
-                //           kick_info[8][sn]*kick_info[8][sn]);
                            
             } else {
                 /* System disrupted by THIS kick, and then Star 1 vanished.
@@ -1245,9 +1230,6 @@ void handle_bse_outcome(long k, long kb, double kick_info[19][2], double tphysf,
                     knew_vty += kick_info[7][sn];
                     knew_vtz += kick_info[8][sn];
 
-                    //vko_sq += (kick_info[6][sn]*kick_info[6][sn] + 
-                    //           kick_info[7][sn]*kick_info[7][sn] + 
-                    //           kick_info[8][sn]*kick_info[8][sn]);
                 } else {
                     /* True disruption without collision. Surviving Star 2 gets Cols 10-12 */
                     star[knew].vr += kick_info[12][sn] * 1.0e5 / (units.l/units.t);
@@ -1255,24 +1237,17 @@ void handle_bse_outcome(long k, long kb, double kick_info[19][2], double tphysf,
                     knew_vty += kick_info[11][sn];
                     knew_vtz += kick_info[12][sn];
 
-                    //vko_sq += (kick_info[10][sn]*kick_info[10][sn] + 
-                    //           kick_info[11][sn]*kick_info[11][sn] + 
-                    //           kick_info[12][sn]*kick_info[12][sn]);
                 }
 
                 //star[knew].vr += kick_info[12][sn] * 1.0e5 / (units.l/units.t);
                 //vt_add_kick(&(star[knew].vt), kick_info[10][sn], kick_info[11][sn], curr_st);
                 
-                //vko_sq += (kick_info[10][sn]*kick_info[10][sn] + 
-                //           kick_info[11][sn]*kick_info[11][sn] + 
-                //           kick_info[12][sn]*kick_info[12][sn]);
             }
         }
     }
     
-    // Finalize legacy VKO calculation
-    //*VKO = sqrt(vko_sq);
-    *VKO = sqrt(knew_vtx*knew_vtx + knew_vty*knew_vty + knew_vtz*knew_vtz);
+    VKO[1] = sqrt(knew_vtx*knew_vtx + knew_vty*knew_vty + knew_vtz*knew_vtz);
+    VKO[0] = 0.0;
 
     if (knew_vtx != 0.0 || knew_vty != 0.0) {
         vt_add_kick(&(star[knew].vt), knew_vtx, knew_vty, curr_st);
@@ -1283,7 +1258,7 @@ void handle_bse_outcome(long k, long kb, double kick_info[19][2], double tphysf,
     for (int sn = 0; sn < 2; sn++) {
         if (kick_info[0][sn] > 0.0) {
             //dprintf("birth kick of %f km/s\n", kick_info[0][sn]);
-            dprintf("birth kick(bin2iso4): TT=%.18g, kick_info[0][sn]=%.18g, kick_info[6][sn]=%.18g, kick_info[7][sn]=%.18g, kick_info[8][sn]=%.18g, vr=%.18g, vt=%.18g, VKO=%.18g id=%ld id1=%ld id2=%ld type1=15 type2=%d\n",TotalTime,kick_info[0][sn],kick_info[6][sn],kick_info[7][sn],kick_info[8][sn],star[k].vr,star[k].vt,VKO, star[knew].id, binary[kb].id1, binary[kb].id2, star[knew].se_k);
+            dprintf("birth kick(bin2iso4): TT=%.18g, kick_info[0][sn]=%.18g, kick_info[6][sn]=%.18g, kick_info[7][sn]=%.18g, kick_info[8][sn]=%.18g, vr=%.18g, vt=%.18g, VKO=%.18g id=%ld id1=%ld id2=%ld type1=15 type2=%d\n",TotalTime,kick_info[0][sn],kick_info[6][sn],kick_info[7][sn],kick_info[8][sn],star[k].vr,star[k].vt,VKO[1], star[knew].id, binary[kb].id1, binary[kb].id2, star[knew].se_k);
         }
     }
     

--- a/src/cmc/cmc_stellar_evolution.c
+++ b/src/cmc/cmc_stellar_evolution.c
@@ -840,7 +840,7 @@ void write_stellar_data(void){
 * @param kick_info ?
 * @param tphysf ?
 */
-void handle_bse_outcome(long k, long kb, double *kick_info, double tphysf, int kprev0, int kprev1, double *VKO)
+void handle_bse_outcome(long k, long kb, double kick_info[19][2], double tphysf, int kprev0, int kprev1, double *VKO)
 {
   int j, jj;
   long knew=0, knewp=0, convert;

--- a/src/cmc/cmc_stellar_evolution.c
+++ b/src/cmc/cmc_stellar_evolution.c
@@ -322,8 +322,8 @@ void stellar_evolution_init(void){
       DMse -= star_m[g_k] * madhoc;
       /* birth kicks */
       if (kick_info[2][0] != 0.0) {
-        fprintf(stderr, "DEBUG 0: birth kick of %f km/s\n", kick_info[2][0]);
-        fflush(stderr);
+        //fprintf(stderr, "DEBUG 0: birth kick of %f km/s\n", kick_info[2][0]);
+        //fflush(stderr);
       }
       star[k].vr += kick_info[8][0] * 1.0e5 / (units.l/units.t);
 
@@ -375,17 +375,9 @@ void stellar_evolution_init(void){
               &(binary[kb].bse_tb), &(binary[kb].e), kick_info, &(binary[kb].bse_bhspin[0]));
       *curr_st=bse_get_taus113state();
 
-      if (binary[kb].bse_mass[0]>20. || binary[kb].bse_mass[1]>20.){
-          fprintf(stderr, "DEBUG 0 (binary): About to extract supernova kick physics from the array.\n");
-          fflush(stderr);
-      }
 
       handle_bse_outcome(k, kb, kick_info, tphysf, kprev0, kprev1, &VKO);
 
-      if (binary[kb].bse_mass[0]>20. || binary[kb].bse_mass[1]>20.){
-          fprintf(stderr, "DEBUG 0 (binary): Successfully processed kick physics without crashing.\n");
-          fflush(stderr);
-      }
 
     } else {
       eprintf("totally confused!\n");
@@ -410,7 +402,7 @@ void stellar_evolution_init(void){
 void do_stellar_evolution(gsl_rng *rng)
 {
   long k, kb, j, jj;
-  int kprev,i, ii;
+  int kprev,i, ii, kk;
   int kprev0, kprev1;
   double dtp, tphysf, kick_info[19][2], VKO;
   double M_beforeSE, M10_beforeSE, M100_beforeSE, M1000_beforeSE, Mcore_beforeSE;
@@ -426,15 +418,6 @@ void do_stellar_evolution(gsl_rng *rng)
 
   //MPI: The serial version runs till N_MAX_NEW+1 to account for the sentinel. But in the parallel version, there is no sentinel, so runs only till N_MAX_NEW.
   for(k=1; k<=clus.N_MAX_NEW; k++){ 
-    if (k == 7762) {
-        if (star[k].binind == 0) {
-            fprintf(stderr, "\n>>> Starting Star %ld (SINGLE) | Type: %d | Mass: %g\n", k, star[k].se_k, star[k].se_mt);
-        } else {
-            kb = star[k].binind;
-            fprintf(stderr, "\n>>> Starting Star %ld (BINARY) | Types: %d/%d | Masses: %g/%g\n", k, binary[kb].bse_kw[0], binary[kb].bse_kw[1], binary[kb].bse_mass[0], binary[kb].bse_mass[1]);
-        }
-        fflush(stderr);
-    }  
 
     int g_k = get_global_idx(k);
     if (star[k].binind == 0) { /* single star */
@@ -587,8 +570,8 @@ void do_stellar_evolution(gsl_rng *rng)
 
         /* birth kicks */
         if (kick_info[2][0] != 0.0) {
-          fprintf(stderr, "DEBUG 4: birth kick of %f km/s\n", kick_info[2][0]);
-          fflush(stderr);
+          //fprintf(stderr, "DEBUG 4: birth kick of %f km/s\n", kick_info[2][0]);
+          //fflush(stderr);
         }
         star[k].vr += kick_info[8][0] * 1.0e5 / (units.l/units.t);
 
@@ -628,6 +611,11 @@ void do_stellar_evolution(gsl_rng *rng)
     if (WRITE_MOREPULSAR_INFO) {
             if (kprev!=13 && star[k].se_k==13) { // newly formed NS
                     parafprintf(newnsfile, "%.18g %g 0 %ld %g %g %g %g %g %d", TotalTime, star_r[g_k], star[k].id,star[k].se_zams_mass,star[k].se_mass, star[k].se_mt, star[k].se_scm_formation, VKO, kprev);
+
+                    for (ii=0; ii<19; ii++){
+                        parafprintf (newnsfile, " %g", kick_info[ii][0]);
+                    }
+
                     parafprintf (newnsfile, "\n");
             }
     }
@@ -685,8 +673,8 @@ void do_stellar_evolution(gsl_rng *rng)
 		if(binary[kb].bse_kw[0] == 14 && binary[kb].bse_kw[1] == 14){
 			integrate_a_e_peters_eqn(kb);
                         for(ii=0;ii<19;ii++) {
-                            for(jj=0;jj<2;jj++){
-                                kick_info[ii][jj] = 0.0;
+                            for(kk=0;kk<2;kk++){
+                                kick_info[ii][kk] = 0.0;
                             }
                         }
 		} else{
@@ -734,14 +722,14 @@ void do_stellar_evolution(gsl_rng *rng)
 		if (kprev0!=14 && binary[kb].bse_kw[0]==14) { // newly formed BH
 			parafprintf(newbhfile, "%.18g %g 1 %ld %g %g %g %g %g", TotalTime, star_r[g_k], prev_id1, binary[kb].bse_zams_mass[0], binary[kb].bse_mass0[0], binary[kb].bse_mass[0], binary[kb].bse_bhspin[0], VKO);
 			for (ii=0; ii<19; ii++){
-				parafprintf (newbhfile, " %g", kick_info[ii][0]);
+			    parafprintf (newbhfile, " %g", kick_info[ii][0]);
 			}
 			parafprintf (newbhfile, "\n");
 		}
 		if (kprev1!=14 && binary[kb].bse_kw[1]==14 && binary[kb].id2 != 0) { // newly formed BH
 			parafprintf(newbhfile, "%.18g %g 1 %ld %g %g %g %g %g", TotalTime, star_r[g_k], prev_id2, binary[kb].bse_zams_mass[1],binary[kb].bse_mass0[1], binary[kb].bse_mass[1], binary[kb].bse_bhspin[1],VKO);
 			for (ii=0; ii<19; ii++){
-				parafprintf (newbhfile, " %g", kick_info[ii][1]);
+			    parafprintf (newbhfile, " %g", kick_info[ii][1]);
 			}
 			parafprintf (newbhfile, "\n");
 		}
@@ -750,10 +738,16 @@ void do_stellar_evolution(gsl_rng *rng)
         if (WRITE_MOREPULSAR_INFO) {
                 if (kprev0!=13 && binary[kb].bse_kw[0]==13) { // newly formed NS
                         parafprintf(newnsfile, "%.18g %g 1 %ld %g %g %g %g %g %d", TotalTime, star_r[g_k], prev_id1, binary[kb].bse_zams_mass[0], binary[kb].bse_mass0[0], binary[kb].bse_mass[0], binary[kb].bse_bcm_formation[0], VKO, kprev0);
+                        for (ii=0; ii<19; ii++){
+                            parafprintf (newnsfile, " %g", kick_info[ii][0]);
+                        }
                         parafprintf(newnsfile, "\n");
                 }
                 if (kprev1!=13 && binary[kb].bse_kw[1]==13 && binary[kb].id2 != 0) { // newly formed NS
                         parafprintf(newnsfile, "%.18g %g 1 %ld %g %g %g %g %g %d", TotalTime, star_r[g_k], prev_id2, binary[kb].bse_zams_mass[1],binary[kb].bse_mass0[1], binary[kb].bse_mass[1], binary[kb].bse_bcm_formation[1],VKO,kprev1);
+                        for (ii=0; ii<19; ii++){
+                            parafprintf (newnsfile, " %g", kick_info[ii][1]);
+                        }
                         parafprintf(newnsfile, "\n");
                 }
         }
@@ -882,8 +876,11 @@ void handle_bse_outcome(long k, long kb, double kick_info[19][2], double tphysf,
   int j, jj;
   long knew=0, knewp=0, convert;
   double dtp;
-
-  knew = 0;
+  double vko_sq = 0.0; //Track the square of the legacy quadrature sum
+  double knew_vtx = 0.0, knew_vty = 0.0, knew_vtz;
+  double knewp_vtx = 0.0, knewp_vty = 0.0, knewp_vtz;
+  
+  //knew = 0;
   *VKO = 0.0;
 
   /* PK: extract some stellar/binary info from BSE's bcm array */
@@ -974,21 +971,38 @@ void handle_bse_outcome(long k, long kb, double kick_info[19][2], double tphysf,
     DMse -= star_m[g_k] * madhoc;
     binary[kb].a = pow((binary[kb].bse_mass[0]+binary[kb].bse_mass[1])*sqr(binary[kb].bse_tb/365.25), 1.0/3.0)
       * AU / units.l;
+
     if (kick_info[2][0] != 0.0 || kick_info[2][1] != 0.0) {
       //dprintf("birth kick of %f and %f km/s\n", kick_info[2][0], kick_info[2][1]);
     }
+    
+    double total_vtx = 0.0, total_vty = 0.0, total_vtz = 0.0;
     for (int sn = 0; sn < 2; sn++) {
         /* kick_info[0][sn] is SN ID */
         if (kick_info[0][sn] > 0.0) { 
           /* Cols 6-8: shared COM kick */
+          /* Sum radial kicks directly */
           star[k].vr += kick_info[8][sn] * 1.0e5 / (units.l/units.t);
-          vt_add_kick(&(star[k].vt), kick_info[6][sn], kick_info[7][sn], curr_st); //will mean a different angle for each kick, should be ok as this is a randomised process.
+    
+          /* Accumulate tangential and radial components */
+          total_vtx += kick_info[6][sn];
+          total_vty += kick_info[7][sn];
+          total_vtz += kick_info[8][sn];
+          //vt_add_kick(&(star[k].vt), kick_info[6][sn], kick_info[7][sn], curr_st); //legacy vs[20] prescription: will mean a different angle for each kick, should be ok as this is a randomised process.
                 
-          *VKO += sqrt(kick_info[6][sn]*kick_info[6][sn] + 
-                       kick_info[7][sn]*kick_info[7][sn] + 
-                       kick_info[8][sn]*kick_info[8][sn]);
+          //*VKO += sqrt(kick_info[6][sn]*kick_info[6][sn] + 
+          //             kick_info[7][sn]*kick_info[7][sn] + 
+          //             kick_info[8][sn]*kick_info[8][sn]);
         }
     }
+    
+    *VKO = sqrt(total_vtx*total_vtx + total_vty*total_vty + total_vtz*total_vtz);
+
+    /* Apply the random rotation to the true vector sum ONCE */
+    if (total_vtx != 0.0 || total_vty != 0.0) {
+        vt_add_kick(&(star[k].vt), total_vtx, total_vty, curr_st);
+    }
+
     set_star_EJ(k);
 
     if (kick_info[2][0] != 0.0) {
@@ -1035,7 +1049,6 @@ void handle_bse_outcome(long k, long kb, double kick_info[19][2], double tphysf,
 
     destroy_obj(k);
 
-    double vko_sq = 0.0; // Track the squares for the legacy quadrature sum
     for (int sn = 0; sn < 2; sn++) {
         if (kick_info[0][sn] > 0.0) {
                 
@@ -1043,33 +1056,62 @@ void handle_bse_outcome(long k, long kb, double kick_info[19][2], double tphysf,
             if (kick_info[1][sn] == 0.0) {
             /* System survived THIS kick, both stars get the COM velocity (Cols 6-8) */
                 star[knew].vr += kick_info[8][sn] * 1.0e5 / (units.l/units.t);
-                vt_add_kick(&(star[knew].vt), kick_info[6][sn], kick_info[7][sn], curr_st);
+                knew_vtx += kick_info[6][sn];
+                knew_vty += kick_info[7][sn];
+                //vt_add_kick(&(star[knew].vt), kick_info[6][sn], kick_info[7][sn], curr_st);
                     
                 star[knewp].vr += kick_info[8][sn] * 1.0e5 / (units.l/units.t);
-                star[knewp].vt = star[knew].vt; // Tangent speeds sync when sharing COM
+                knewp_vtx += kick_info[6][sn];
+                knewp_vty += kick_info[7][sn];
+                //star[knewp].vt = star[knew].vt; // Tangent speeds sync when sharing COM
                     
+                vko_sq += (kick_info[6][sn]*kick_info[6][sn] +
+                           kick_info[7][sn]*kick_info[7][sn] +
+                           kick_info[8][sn]*kick_info[8][sn]);
             } else {
                 /* System disrupted by THIS kick. Apply runaway vectors by Star ID */
                     
                 /* Star 1 (knew) always gets Cols 6-8 */
                 star[knew].vr += kick_info[8][sn] * 1.0e5 / (units.l/units.t);
-                vt_add_kick(&(star[knew].vt), kick_info[6][sn], kick_info[7][sn], curr_st);
+                knew_vtx += kick_info[6][sn];
+                knew_vty += kick_info[7][sn];
+                //vt_add_kick(&(star[knew].vt), kick_info[6][sn], kick_info[7][sn], curr_st);
                     
                 /* Star 2 (knewp) always gets Cols 10-12 */
                 star[knewp].vr += kick_info[12][sn] * 1.0e5 / (units.l/units.t);
-                vt_add_kick(&(star[knewp].vt), kick_info[10][sn], kick_info[11][sn], curr_st);
+                knewp_vtx += kick_info[10][sn];
+                knewp_vty += kick_info[11][sn];
+                //vt_add_kick(&(star[knewp].vt), kick_info[10][sn], kick_info[11][sn], curr_st);
+                
+                /* Log the correct star's runaway magnitude */
+                if (sn == 0) {
+                    vko_sq += (kick_info[6][sn]*kick_info[6][sn] +
+                               kick_info[7][sn]*kick_info[7][sn] +
+                               kick_info[8][sn]*kick_info[8][sn]);
+                } else {
+                    vko_sq += (kick_info[10][sn]*kick_info[10][sn] +
+                               kick_info[11][sn]*kick_info[11][sn] +
+                               kick_info[12][sn]*kick_info[12][sn]);
+                }
             }        
             
             // Legacy Disrupted Math: Only track Star 1's columns (6-8) as a sum of squares
-            vko_sq += (kick_info[6][sn]*kick_info[6][sn] + 
-                       kick_info[7][sn]*kick_info[7][sn] + 
-                       kick_info[8][sn]*kick_info[8][sn]); 
+            //vko_sq += (kick_info[6][sn]*kick_info[6][sn] + 
+            //           kick_info[7][sn]*kick_info[7][sn] + 
+            //           kick_info[8][sn]*kick_info[8][sn]); 
             
         }
     }
     // Finalize the legacy VKO calculation outside the loop
     *VKO = sqrt(vko_sq);    
-    
+    /* Apply vectors outside the loop */
+    if (knew_vtx != 0.0 || knew_vty != 0.0) {
+        vt_add_kick(&(star[knew].vt), knew_vtx, knew_vty, curr_st);
+    }
+    if (knewp_vtx != 0.0 || knewp_vty != 0.0) {
+        vt_add_kick(&(star[knewp].vt), knewp_vtx, knewp_vty, curr_st);
+    }    
+
     set_star_EJ(knew);
     set_star_EJ(knewp);    
 
@@ -1106,15 +1148,27 @@ void handle_bse_outcome(long k, long kb, double kick_info[19][2], double tphysf,
     
     for (int sn = 0; sn < 2; sn++) {
         if (kick_info[0][sn] > 0.0) {
-            /* Surviving star acts as the COM, gets Cols 6-8 */
+            /* Whether the system merged (COM kick) or disrupted (Runaway kick), 
+               kick.f strictly routes Star 1's velocity to Cols 6-8. */
             star[knew].vr += kick_info[8][sn] * 1.0e5 / (units.l/units.t);
-            vt_add_kick(&(star[knew].vt), kick_info[6][sn], kick_info[7][sn], curr_st);
+            knew_vtx += kick_info[6][sn];
+            knew_vty += kick_info[7][sn];
+            knew_vtz += kick_info[8][sn];
+            //vt_add_kick(&(star[knew].vt), kick_info[6][sn], kick_info[7][sn], curr_st);
                 
-            *VKO += sqrt(kick_info[6][sn]*kick_info[6][sn] + 
-                         kick_info[7][sn]*kick_info[7][sn] + 
-                         kick_info[8][sn]*kick_info[8][sn]);
+            //vko_sq += (kick_info[6][sn]*kick_info[6][sn] + 
+            //           kick_info[7][sn]*kick_info[7][sn] + 
+            //           kick_info[8][sn]*kick_info[8][sn]);
+
         }
     }
+    //*VKO = sqrt(vko_sq);
+    *VKO = sqrt(knew_vtx*knew_vtx + knew_vty*knew_vty + knew_vtz*knew_vtz);
+
+    if (knew_vtx != 0.0 || knew_vty != 0.0) {
+        vt_add_kick(&(star[knew].vt), knew_vtx, knew_vty, curr_st);
+    }    
+
     set_star_EJ(knew);
 
     if (kick_info[2][0] != 0.0) {
@@ -1163,8 +1217,6 @@ void handle_bse_outcome(long k, long kb, double kick_info[19][2], double tphysf,
         }
     }
 
-    double vko_sq = 0.0; // Track squares for legacy quadrature sum
-
     for (int sn = 0; sn < 2; sn++) {
         if (kick_info[0][sn] > 0.0) {
             
@@ -1173,27 +1225,59 @@ void handle_bse_outcome(long k, long kb, double kick_info[19][2], double tphysf,
                 /* System merged or survived THIS kick. 
  *                    Surviving Star 2 acts as COM, gets Cols 6-8 */
                 star[knew].vr += kick_info[8][sn] * 1.0e5 / (units.l/units.t);
-                vt_add_kick(&(star[knew].vt), kick_info[6][sn], kick_info[7][sn], curr_st);
+                knew_vtx += kick_info[6][sn];
+                knew_vty += kick_info[7][sn];
+                knew_vtz += kick_info[8][sn];
+                //vt_add_kick(&(star[knew].vt), kick_info[6][sn], kick_info[7][sn], curr_st);
                 
-                vko_sq += (kick_info[6][sn]*kick_info[6][sn] + 
-                           kick_info[7][sn]*kick_info[7][sn] + 
-                           kick_info[8][sn]*kick_info[8][sn]);
+                //vko_sq += (kick_info[6][sn]*kick_info[6][sn] + 
+                //           kick_info[7][sn]*kick_info[7][sn] + 
+                //           kick_info[8][sn]*kick_info[8][sn]);
                            
             } else {
                 /* System disrupted by THIS kick, and then Star 1 vanished.
  *                    Surviving Star 2 gets its specific runaway vectors from Cols 10-12 */
-                star[knew].vr += kick_info[12][sn] * 1.0e5 / (units.l/units.t);
-                vt_add_kick(&(star[knew].vt), kick_info[10][sn], kick_info[11][sn], curr_st);
+                /* Check for Collision Override */
+                if (kick_info[10][sn] == 0.0 && kick_info[11][sn] == 0.0 && kick_info[12][sn] == 0.0) {
+                    /* Collision occurred! BSE dumped Star 2's velocity into Cols 6-8 */
+                    star[knew].vr += kick_info[8][sn] * 1.0e5 / (units.l/units.t);
+                    knew_vtx += kick_info[6][sn];
+                    knew_vty += kick_info[7][sn];
+                    knew_vtz += kick_info[8][sn];
+
+                    //vko_sq += (kick_info[6][sn]*kick_info[6][sn] + 
+                    //           kick_info[7][sn]*kick_info[7][sn] + 
+                    //           kick_info[8][sn]*kick_info[8][sn]);
+                } else {
+                    /* True disruption without collision. Surviving Star 2 gets Cols 10-12 */
+                    star[knew].vr += kick_info[12][sn] * 1.0e5 / (units.l/units.t);
+                    knew_vtx += kick_info[10][sn];
+                    knew_vty += kick_info[11][sn];
+                    knew_vtz += kick_info[12][sn];
+
+                    //vko_sq += (kick_info[10][sn]*kick_info[10][sn] + 
+                    //           kick_info[11][sn]*kick_info[11][sn] + 
+                    //           kick_info[12][sn]*kick_info[12][sn]);
+                }
+
+                //star[knew].vr += kick_info[12][sn] * 1.0e5 / (units.l/units.t);
+                //vt_add_kick(&(star[knew].vt), kick_info[10][sn], kick_info[11][sn], curr_st);
                 
-                vko_sq += (kick_info[10][sn]*kick_info[10][sn] + 
-                           kick_info[11][sn]*kick_info[11][sn] + 
-                           kick_info[12][sn]*kick_info[12][sn]);
+                //vko_sq += (kick_info[10][sn]*kick_info[10][sn] + 
+                //           kick_info[11][sn]*kick_info[11][sn] + 
+                //           kick_info[12][sn]*kick_info[12][sn]);
             }
         }
     }
     
     // Finalize legacy VKO calculation
-    *VKO = sqrt(vko_sq);         
+    //*VKO = sqrt(vko_sq);
+    *VKO = sqrt(knew_vtx*knew_vtx + knew_vty*knew_vty + knew_vtz*knew_vtz);
+
+    if (knew_vtx != 0.0 || knew_vty != 0.0) {
+        vt_add_kick(&(star[knew].vt), knew_vtx, knew_vty, curr_st);
+    }
+         
     set_star_EJ(knew);
 
     for (int sn = 0; sn < 2; sn++) {

--- a/src/cmc/cmc_stellar_evolution.c
+++ b/src/cmc/cmc_stellar_evolution.c
@@ -1112,7 +1112,7 @@ void handle_bse_outcome(long k, long kb, double kick_info[19][2], double tphysf,
     }
     if (kick_info[2][1] != 0.0) {
       //dprintf("birth kick of %f km/s\n", kick_info[2][0]);
-      dprintf("birth kick(bin2iso2): TT=%.18g, kick_info[0][1]=%.18g, kick_info[6][1]=%.18g, kick_info[7][1]=%.18g, kick_info[8][1]=%.18g, vr=%.18g, vt=%.18g, VK=%.18g id1=%ld id2=%ld pid1=%ld pid2=%ld type1=%d type2=%d\n",TotalTime,kick_info[0][1],kick_info[6][1],kick_info[7][1],kick_info[8][1],star[k].vr,star[k].vt,VKO,star[knew].id,star[knew].id,binary[kb].id1,binary[kb].id2,star[knew].se_k,star[knewp].se_k);
+      dprintf("birth kick(bin2iso2): TT=%.18g, kick_info[0][1]=%.18g, kick_info[6][1]=%.18g, kick_info[7][1]=%.18g, kick_info[8][1]=%.18g, vr=%.18g, vt=%.18g, VK=%.18g id1=%ld id2=%ld pid1=%ld pid2=%ld type1=%d type2=%d\n",TotalTime,kick_info[0][1],kick_info[6][1],kick_info[7][1],kick_info[8][1],star[k].vr,star[k].vt,VKO[1],star[knew].id,star[knew].id,binary[kb].id1,binary[kb].id2,star[knew].se_k,star[knewp].se_k);
     }
 
   } else if (binary[kb].bse_mass[0] != 0.0 && binary[kb].bse_mass[1] == 0.0) {

--- a/src/cmc/cmc_stellar_evolution.c
+++ b/src/cmc/cmc_stellar_evolution.c
@@ -81,6 +81,20 @@ void restart_stellar_evolution(void){
   bse_set_gamma(BSE_GAMMA);
   bse_set_merger(-1.0);
   
+  /* COSMIC 4.0: select stellar engine and (if METISSE) push track paths into
+   * the Fortran COMMON blocks BEFORE bse_zcnsts. The Fortran dispatchers in
+   * deltat.f / mlwind.f / hrdiag.f branch on these flags; if both default to 0
+   * stellar evolution silently no-ops. */
+  if (STELLAR_ENGINE == 1) {
+    if (PATH_TO_TRACKS == NULL || PATH_TO_HE_TRACKS == NULL) {
+      eprintf("ERROR: STELLAR_ENGINE=metisse requires both PATH_TO_TRACKS and PATH_TO_HE_TRACKS.\n");
+      exit_cleanly(-1, __FUNCTION__);
+    }
+    bse_set_metisse_inputs(PATH_TO_TRACKS, PATH_TO_HE_TRACKS,
+                           Z_MATCH_LIMIT, (int) METISSE_VERBOSE);
+  }
+  bse_set_stellar_engine((int) STELLAR_ENGINE);
+
   /* set parameters relating to metallicity */
   zpars = (double *) malloc(20 * sizeof(double));
   bse_zcnsts(&METALLICITY, zpars);
@@ -180,6 +194,20 @@ void stellar_evolution_init(void){
   bse_set_gamma(BSE_GAMMA);
   bse_set_merger(-1.0);
   
+  /* COSMIC 4.0: select stellar engine and (if METISSE) push track paths into
+   * the Fortran COMMON blocks BEFORE bse_zcnsts. The Fortran dispatchers in
+   * deltat.f / mlwind.f / hrdiag.f branch on these flags; if both default to 0
+   * stellar evolution silently no-ops. */
+  if (STELLAR_ENGINE == 1) {
+    if (PATH_TO_TRACKS == NULL || PATH_TO_HE_TRACKS == NULL) {
+      eprintf("ERROR: STELLAR_ENGINE=metisse requires both PATH_TO_TRACKS and PATH_TO_HE_TRACKS.\n");
+      exit_cleanly(-1, __FUNCTION__);
+    }
+    bse_set_metisse_inputs(PATH_TO_TRACKS, PATH_TO_HE_TRACKS,
+                           Z_MATCH_LIMIT, (int) METISSE_VERBOSE);
+  }
+  bse_set_stellar_engine((int) STELLAR_ENGINE);
+
   /* set parameters relating to metallicity */
   zpars = (double *) malloc(20 * sizeof(double));
   bse_zcnsts(&METALLICITY, zpars);
@@ -817,7 +845,7 @@ void handle_bse_outcome(long k, long kb, double *vs, double tphysf, int kprev0, 
   int j, jj;
   long knew=0, knewp=0, convert;
   double dtp;
-  
+
   knew = 0;
   *VKO = 0.0;
 
@@ -1300,9 +1328,10 @@ void handle_bse_outcome(long k, long kb, double *vs, double tphysf, int kprev0, 
                 	} else {
                         	write_morepulsar(k);
 
-                	}	
-        	}	
+                	}
+        	}
 	}
+
 }
 
 /**

--- a/src/utils/addbinaries/addbinaries.c
+++ b/src/utils/addbinaries/addbinaries.c
@@ -129,7 +129,7 @@ void assign_binaries(cmc_fits_data_t *cfd, long Nbin, int limits, double peak_a,
 	double kTcore, vcore, Eb, Ebmin, Ebmax, timeunitcgs, mtotal, m1, m2, X, qbin;
 	double *r, *sigma, *mave, dtp, tphysf;
 	star_t star;
-	double vs[20];
+	double kick_info[19][2];
 	
 	/* initialize stellar evolution */
 	/* SSE */
@@ -392,7 +392,7 @@ void assign_binaries(cmc_fits_data_t *cfd, long Nbin, int limits, double peak_a,
 				bse_evolve_single(&(star.se_k), &(star.se_mass), &(star.se_mt), &(star.se_radius),
 					   &(star.se_lum), &(star.se_mc), &(star.se_rc), &(star.se_menv), 
 				   	&(star.se_renv), &(star.se_ospin), &(star.se_epoch), &(star.se_tms), 
-				   	&(star.se_tphys), &tphysf, &dtp, &METALLICITY, zpars, vs, &(star.se_bhspin));
+				   	&(star.se_tphys), &tphysf, &dtp, &METALLICITY, zpars, kick_info, &(star.se_bhspin));
 
 				/* setting star properties in FITS file, being careful with units */
 				cfd->bs_k2[j] = star.se_k;
@@ -449,7 +449,7 @@ void assign_binaries(cmc_fits_data_t *cfd, long Nbin, int limits, double peak_a,
 				bse_evolve_single(&(star.se_k), &(star.se_mass), &(star.se_mt), &(star.se_radius),
 					   &(star.se_lum), &(star.se_mc), &(star.se_rc), &(star.se_menv), 
 				   	&(star.se_renv), &(star.se_ospin), &(star.se_epoch), &(star.se_tms), 
-				   	&(star.se_tphys), &tphysf, &dtp, &METALLICITY, zpars, vs, &(star.se_bhspin));
+				   	&(star.se_tphys), &tphysf, &dtp, &METALLICITY, zpars, kick_info, &(star.se_bhspin));
 
 				/* setting star properties in FITS file, being careful with units */
 				cfd->bs_k2[j] = star.se_k;
@@ -506,7 +506,7 @@ void assign_binaries(cmc_fits_data_t *cfd, long Nbin, int limits, double peak_a,
 				bse_evolve_single(&(star.se_k), &(star.se_mass), &(star.se_mt), &(star.se_radius),
 					   &(star.se_lum), &(star.se_mc), &(star.se_rc), &(star.se_menv), 
 				   	&(star.se_renv), &(star.se_ospin), &(star.se_epoch), &(star.se_tms), 
-				   	&(star.se_tphys), &tphysf, &dtp, &METALLICITY, zpars, vs, &(star.se_bhspin));
+				   	&(star.se_tphys), &tphysf, &dtp, &METALLICITY, zpars, kick_info, &(star.se_bhspin));
 
 				/* setting star properties in FITS file, being careful with units */
 				cfd->bs_k2[j] = star.se_k;
@@ -569,7 +569,7 @@ void assign_binaries(cmc_fits_data_t *cfd, long Nbin, int limits, double peak_a,
 					bse_evolve_single(&(star.se_k), &(star.se_mass), &(star.se_mt), &(star.se_radius),
 						   &(star.se_lum), &(star.se_mc), &(star.se_rc), &(star.se_menv), 
 					   	&(star.se_renv), &(star.se_ospin), &(star.se_epoch), &(star.se_tms), 
-					   	&(star.se_tphys), &tphysf, &dtp, &METALLICITY, zpars, vs, &(star.se_bhspin));
+					   	&(star.se_tphys), &tphysf, &dtp, &METALLICITY, zpars, kick_info, &(star.se_bhspin));
 					
 					/* setting star properties in FITS file, being careful with units */
 					cfd->bs_k2[j] = star.se_k;
@@ -596,7 +596,7 @@ void assign_binaries(cmc_fits_data_t *cfd, long Nbin, int limits, double peak_a,
 					bse_evolve_single(&(star.se_k), &(star.se_mass), &(star.se_mt), &(star.se_radius),
 						   &(star.se_lum), &(star.se_mc), &(star.se_rc), &(star.se_menv), 
 					   	&(star.se_renv), &(star.se_ospin), &(star.se_epoch), &(star.se_tms), 
-					   	&(star.se_tphys), &tphysf, &dtp, &METALLICITY, zpars, vs, &(star.se_bhspin));
+					   	&(star.se_tphys), &tphysf, &dtp, &METALLICITY, zpars, kick_info, &(star.se_bhspin));
 					
 					/* setting star properties in FITS file, being careful with units */
 					cfd->bs_k1[j] = star.se_k;
@@ -648,7 +648,7 @@ void assign_binaries(cmc_fits_data_t *cfd, long Nbin, int limits, double peak_a,
 				bse_evolve_single(&(star.se_k), &(star.se_mass), &(star.se_mt), &(star.se_radius),
 					   &(star.se_lum), &(star.se_mc), &(star.se_rc), &(star.se_menv), 
 				   	&(star.se_renv), &(star.se_ospin), &(star.se_epoch), &(star.se_tms), 
-				   	&(star.se_tphys), &tphysf, &dtp, &METALLICITY, zpars, vs, &(star.se_bhspin));
+				   	&(star.se_tphys), &tphysf, &dtp, &METALLICITY, zpars, kick_info, &(star.se_bhspin));
 
 				/* setting star properties in FITS file, being careful with units */
 				cfd->bs_k2[j] = star.se_k;
@@ -719,7 +719,7 @@ void assign_binaries(cmc_fits_data_t *cfd, long Nbin, int limits, double peak_a,
 				bse_evolve_single(&(star.se_k), &(star.se_mass), &(star.se_mt), &(star.se_radius),
 					   &(star.se_lum), &(star.se_mc), &(star.se_rc), &(star.se_menv), 
 				   	&(star.se_renv), &(star.se_ospin), &(star.se_epoch), &(star.se_tms), 
-				   	&(star.se_tphys), &tphysf, &dtp, &METALLICITY, zpars, vs, &(star.se_bhspin));
+				   	&(star.se_tphys), &tphysf, &dtp, &METALLICITY, zpars, kick_info, &(star.se_bhspin));
 
 				/* setting star properties in FITS file, being careful with units */
 				cfd->bs_k2[j] = star.se_k;
@@ -745,7 +745,7 @@ void assign_binaries(cmc_fits_data_t *cfd, long Nbin, int limits, double peak_a,
 				bse_evolve_single(&(star.se_k), &(star.se_mass), &(star.se_mt), &(star.se_radius),
 					   &(star.se_lum), &(star.se_mc), &(star.se_rc), &(star.se_menv), 
 				   	&(star.se_renv), &(star.se_ospin), &(star.se_epoch), &(star.se_tms), 
-				   	&(star.se_tphys), &tphysf, &dtp, &METALLICITY, zpars, vs, &(star.se_bhspin));
+				   	&(star.se_tphys), &tphysf, &dtp, &METALLICITY, zpars, kick_info, &(star.se_bhspin));
 
 				/* setting star properties in FITS file, being careful with units */
 				cfd->bs_k1[j] = star.se_k;
@@ -809,7 +809,7 @@ void assign_binaries(cmc_fits_data_t *cfd, long Nbin, int limits, double peak_a,
 				bse_evolve_single(&(star.se_k), &(star.se_mass), &(star.se_mt), &(star.se_radius),
 					   &(star.se_lum), &(star.se_mc), &(star.se_rc), &(star.se_menv), 
 				   	&(star.se_renv), &(star.se_ospin), &(star.se_epoch), &(star.se_tms), 
-				   	&(star.se_tphys), &tphysf, &dtp, &METALLICITY, zpars, vs, &(star.se_bhspin));
+				   	&(star.se_tphys), &tphysf, &dtp, &METALLICITY, zpars, kick_info, &(star.se_bhspin));
 				/* setting star properties in FITS file, being careful with units */
 				cfd->bs_k2[j] = star.se_k;
 				cfd->bs_m2[j] = star.se_mass / cfd->Mclus;

--- a/src/utils/setstellar/setstellar.c
+++ b/src/utils/setstellar/setstellar.c
@@ -35,7 +35,7 @@ void stellar_evolve(cmc_fits_data_t *cfd)
 	long int k;
 	double frac, dtp, tphysf;
 	star_t star;
-	double vs[20];
+	double kick_info[19][2];
 
 	/* initialize stellar evolution */
 	/* SSE */
@@ -202,7 +202,7 @@ void stellar_evolve(cmc_fits_data_t *cfd)
 			bse_evolve_single(&(star.se_k), &(star.se_mass), &(star.se_mt), &(star.se_radius),
 				   &(star.se_lum), &(star.se_mc), &(star.se_rc), &(star.se_menv), 
 				   &(star.se_renv), &(star.se_ospin), &(star.se_epoch), &(star.se_tms), 
-				   &(star.se_tphys), &tphysf, &dtp, &METALLICITY, zpars, vs, &(star.se_bhspin));
+				   &(star.se_tphys), &tphysf, &dtp, &METALLICITY, zpars, kick_info, &(star.se_bhspin));
 			
 			/* setting star properties in FITS file, being careful with units */
 			cfd->obj_k[k] = star.se_k;


### PR DESCRIPTION
Brings CMC up to date with COSMIC 4.0 (submodule bump `f1a5de0` → `3004c39`, on COSMIC upstream `develop`, two commits past v4.0.1) and reworks natal-kick handling for the new COSMIC API.

## COSMIC 4.0 upgrade

- Bump the COSMIC submodule to `3004c39` and rewrite `src/bse_wrap/bse/CMakeLists.txt` for the 4.0 source layout (`SSE/` split, METISSE sources, `evolv1.f`/`comprad.f` moved out of the build). CMC takes ownership of the Tausworth RNG sources (`taus113-ran3.f`, `tausworth.f`, `tausworth.h` under `src/bse_wrap/bse/`).
- Update C wrapper signatures and COMMON-block externs for the 4.0 API (`evolv2`/`star`/`mix`/`comenv` argument changes, BCM/BPP 49→52 columns, scalar→array setters for `acc_lim`/`alpha1`, etc.).
- Build fixes for macOS: use xcrun's `ar`/`ranlib` on Apple; gate `-Wl,--no-relax` (GNU-ld-only, needed on some HPC Linux links) behind `CMAKE_SYSTEM_NAME STREQUAL "Linux"`; add a `bse_init_umax()` workaround for Apple's linker stripping COSMIC's `int64.o` BLOCK DATA from the static archive, which left `umax = 0` and silently broke the Tausworth RNG on Mac builds.
- Wire stellar-engine selection (SSE vs METISSE) through the INI parser and `bse_set_stellar_engine`, with METISSE track paths/verbosity plumbed through the `[sse]` section. Default behavior (SSE) is unchanged.

## Natal-kick rework (@claireshiye, with fixes from @elenagonzalez870)

COSMIC removed the `bkick` array in favor of `kick_info`, and errors in CMC's `vs[20]` mirror of `bkick` could go unnoticed. This PR:

- Replaces `vs[20]` with COSMIC's `kick_info[19][2]` end-to-end (with the Fortran→C array conversion) and rewrites the supernova-kick handling in `handle_bse_outcome` for the new structure (`kick_info` is per-star by row, while `vs` was chronological).
- Fixes the kick-velocity summation (vector vs scalar sum depending on the outcome branch), adds missing arguments to the `kick_` call, and passes `tphys` to `comenv_`.
- Changes `VKO` to `VKO[2]` in the `nsformation`/`bhformation` output so two supernovae in one binary in one COSMIC step are both recorded, and outputs the full `kick_info` array in both files (column-format change).
- Updates the example/CI ini files for the positive/negative `kickflag` conventions.

Build note: the new COSMIC pin nests METISSE as a submodule inside COSMIC, so a fresh checkout needs `git submodule update --init --recursive`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
