### PR TITLE
Allow MPI oversubscription in the CI test run

### DIFF
--- a/ci/run_cmc_tests.sh
+++ b/ci/run_cmc_tests.sh
@@ -1,2 +1,2 @@
 python make_initial_conditions.py
-mpirun -n 2 ./bin/cmc Params.ini initial
+mpirun --oversubscribe -n 2 ./bin/cmc Params.ini initial


### PR DESCRIPTION
GitHub's private-repo runners expose a single physical core, so Open MPI computes one slot and `mpirun -n 2` aborts before the test starts; public-repo runners have two cores and pass. `--oversubscribe` lifts the slot check without changing the two-rank test itself, so the same `ci/run_cmc_tests.sh` works in both this repo and the private dev repo.

No behavior change on this repo's runners — the flag is a no-op when enough slots exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
