### PR TITLE
Probe -std=gnu17 directly instead of setting CMAKE_C_STANDARD

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,9 +22,15 @@ project(CMC VERSION 1.0.0 LANGUAGES C Fortran)
 # defaults to C23 (gnu23), which turns those long-standing idioms into hard
 # errors (e.g. conflicting decls of inv_comm_create); GCC 14 defaulted to gnu17.
 # Pin gnu17 so a compiler default-standard bump doesn't break the build.
-set(CMAKE_C_STANDARD 17)
-set(CMAKE_C_STANDARD_REQUIRED ON)
-set(CMAKE_C_EXTENSIONS ON)
+# Deliberately NOT via CMAKE_C_STANDARD: CMake accepts the value 17 only from
+# 3.21 and knows C17 flags only for some compilers (GCC >= 8, not classic icc),
+# so the property form breaks configure on older cluster toolchains. Compilers
+# that don't accept -std=gnu17 default to gnu11 or older, which builds fine.
+include(CheckCCompilerFlag)
+check_c_compiler_flag(-std=gnu17 C_COMPILER_HAS_STD_GNU17)
+if(C_COMPILER_HAS_STD_GNU17 AND NOT CMAKE_C_FLAGS MATCHES "-std=")
+  string(APPEND CMAKE_C_FLAGS " -std=gnu17")
+endif()
 
 # On macOS, force Xcode's ar/ranlib (BSD-format archives) over any Homebrew
 # binutils GNU ar that may be earlier in PATH. Apple's ld rejects SysV-format


### PR DESCRIPTION
CMAKE_C_STANDARD 17 requires CMake >= 3.21 and a compiler that CMake has C17 flag entries for (GCC >= 8, never classic icc), so configure failed in the first try_compile on older cluster toolchains (e.g. cmake 3.15.4 + Intel 19.0.5) with "CMake does not know the compile flags to use to enable it". Feature-test -std=gnu17 and append it to CMAKE_C_FLAGS instead: compilers that accept the flag still get the gnu17 pin that GCC 15 needs, and compilers too old to know gnu17 keep their default standard, which is how CMC always built on them.