### PR TITLE
Update website workflow to Python 3.10 for COSMIC's meson-python build

### DIFF
--- a/.github/workflows/deploy-github-pages.yml
+++ b/.github/workflows/deploy-github-pages.yml
@@ -12,13 +12,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.8]
+        python-version: ['3.10']
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Checkout submodules
@@ -38,7 +38,7 @@ jobs:
 
     - name: Deploy to GitHub Pages
       if: success()
-      uses: crazy-max/ghaction-github-pages@v2
+      uses: crazy-max/ghaction-github-pages@v4
       with:
         target_branch: gh-pages
         build_dir: docs/sphinx/build/html/

--- a/.github/workflows/deploy-github-pages.yml
+++ b/.github/workflows/deploy-github-pages.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+  pull_request:
 
 jobs:
   build:
@@ -37,7 +38,7 @@ jobs:
         touch docs/sphinx/build/html/.nojekyll
 
     - name: Deploy to GitHub Pages
-      if: success()
+      if: success() && github.event_name == 'push'
       uses: crazy-max/ghaction-github-pages@v4
       with:
         target_branch: gh-pages


### PR DESCRIPTION
Since the COSMIC 4.x submodule bump (#79), COSMIC installs via meson-python, which requires Python >= 3.10 — so the Website Deploy workflow dies at `pip install src/bse_wrap/bse/COSMIC` on its Python 3.8:

```
meson-python: error: The package requires Python version >=3.10, running on 3.8.18
```

This moves the workflow to Python `'3.10'` and the same action versions COSMIC's own workflows use (`checkout@v4`, `setup-python@v5`, `ghaction-github-pages@v4`). No changes to the apt/pip dependency lists or the Sphinx build steps.

Note: the `make html` step builds master's docs, so the deploy likely stays red until #74 (the docs-build fix) is also merged — the two together should produce the first green deploy since the 4.x bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
